### PR TITLE
J3 — Navigation & Pages vides (config nav, routes lazy, scaffolding)

### DIFF
--- a/src/components/system/EmptyState.tsx
+++ b/src/components/system/EmptyState.tsx
@@ -1,0 +1,25 @@
+import { Button } from "@/components/ui/button";
+
+type Props = {
+  title: string;
+  description?: string;
+  actionLabel?: string;
+  onAction?: () => void;
+};
+export default function EmptyState({ title, description, actionLabel, onAction }: Props) {
+  return (
+    <div className="rounded-lg border p-4 sm:p-6 text-sm">
+      <div className="space-y-2">
+        <div className="text-sm sm:text-base font-medium">{title}</div>
+        {description ? (
+          <div className="text-xs sm:text-sm text-muted-foreground">{description}</div>
+        ) : null}
+        {actionLabel && onAction ? (
+          <div className="pt-2">
+            <Button onClick={onAction} className="h-9 sm:h-10">{actionLabel}</Button>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/src/components/system/PageHeader.tsx
+++ b/src/components/system/PageHeader.tsx
@@ -1,0 +1,18 @@
+type Props = {
+  title: string;
+  description?: string;
+  right?: React.ReactNode;
+};
+export default function PageHeader({ title, description, right }: Props) {
+  return (
+    <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-2 sm:gap-4">
+      <div className="space-y-1">
+        <h1 className="text-xl sm:text-2xl font-semibold">{title}</h1>
+        {description ? (
+          <p className="text-xs sm:text-sm text-muted-foreground">{description}</p>
+        ) : null}
+      </div>
+      {right ? <div className="shrink-0">{right}</div> : null}
+    </div>
+  );
+}

--- a/src/components/system/PageSkeleton.tsx
+++ b/src/components/system/PageSkeleton.tsx
@@ -1,0 +1,9 @@
+export default function PageSkeleton() {
+  return (
+    <div className="p-4 sm:p-6 space-y-3 sm:space-y-3">
+      <div className="h-6 w-40 sm:w-56 rounded bg-muted animate-pulse" />
+      <div className="h-4 w-48 sm:w-72 rounded bg-muted animate-pulse" />
+      <div className="h-24 sm:h-32 w-full rounded bg-muted animate-pulse" />
+    </div>
+  );
+}

--- a/src/config/nav.ts
+++ b/src/config/nav.ts
@@ -1,18 +1,47 @@
-import { Home, User, Users, Banknote, Coins, FileBarChart, Settings } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import {
+  Home,
+  Banknote,
+  Users,
+  Coins,
+  FileBarChart,
+  CalendarCheck,
+  CreditCard,
+  User as UserIcon,
+  Settings as SettingsIcon,
+} from "lucide-react";
 
-export const nav = [
-  { group: "Overview", items: [
-    { to: "/dashboard/home", labelKey: "nav.dashboard", fallback: "Home", icon: Home },
-  ]},
-  { group: "Money", items: [
-    { to: "/dashboard/banks",   labelKey: "nav.banks",   fallback: "Banks",   icon: Banknote },
-    { to: "/dashboard/members", labelKey: "nav.members", fallback: "Members", icon: Users },
-    { to: "/dashboard/incomes", labelKey: "nav.incomes", fallback: "Incomes", icon: Coins },
-    { to: "/dashboard/expenses",labelKey: "nav.expenses",fallback: "Expenses",icon: Coins },
-    { to: "/dashboard/budgets", labelKey: "nav.budgets", fallback: "Budgets", icon: FileBarChart },
-  ]},
-  { group: "Settings", items: [
-    { to: "/dashboard/settings/user",    labelKey: "settings.user",    fallback: "User",    icon: User },
-    { to: "/dashboard/settings/session", labelKey: "settings.session", fallback: "Session", icon: Settings },
-  ]},
-] as const;
+type NavItem = {
+  to: string;
+  labelKey: string;
+  fallback: string; // utilisé par NavList: t(labelKey, fallback)
+  icon: LucideIcon;
+};
+
+type NavSection = {
+  group: string;     // affiché tel quel par NavList
+  items: NavItem[];
+};
+
+// Deux sections: principale & paramètres (tu peux renommer les group labels)
+export const nav: NavSection[] = [
+  {
+    group: "Dashboard",
+    items: [
+      { to: "/dashboard/home",         labelKey: "nav.home",         fallback: "Home",         icon: Home },
+      { to: "/dashboard/banks",        labelKey: "nav.banks",        fallback: "Banks",        icon: Banknote },
+      { to: "/dashboard/members",      labelKey: "nav.members",      fallback: "Members",      icon: Users },
+      { to: "/dashboard/incomes",      labelKey: "nav.incomes",      fallback: "Incomes",      icon: Coins },
+      { to: "/dashboard/expenses",     labelKey: "nav.expenses",     fallback: "Fixed exp.",   icon: FileBarChart },
+      { to: "/dashboard/budgets",      labelKey: "nav.budgets",      fallback: "Budgets",      icon: CalendarCheck },
+      { to: "/dashboard/transactions", labelKey: "nav.transactions", fallback: "Transactions", icon: CreditCard },
+    ],
+  },
+  {
+    group: "Paramètres",
+    items: [
+      { to: "/dashboard/settings/profile", labelKey: "nav.profile",  fallback: "Profile",  icon: UserIcon },
+      { to: "/dashboard/settings/session", labelKey: "nav.sessions", fallback: "Sessions", icon: SettingsIcon },
+    ],
+  },
+];

--- a/src/i18n/resources/en.json
+++ b/src/i18n/resources/en.json
@@ -21,7 +21,10 @@
     "budgets": "Budgets",
     "settings": "Settings",
     "signup": "Sign up",
-    "login": "Log in"
+    "login": "Log in",
+    "home": "Home",
+    "transactions": "Transactions",
+    "sessions": "Sessions"
   },
   "settings": {
     "language": "Language",

--- a/src/i18n/resources/en.json
+++ b/src/i18n/resources/en.json
@@ -8,7 +8,10 @@
     "common": {
       "empty": "Content coming soon.",
       "noSession": "No active session.",
-      "sessionBound": "Data bound to session: {{id}}"
+      "sessionBound": "Data bound to session: {{id}}",
+      "emptyTitle": "Content coming soon",
+      "emptyDesc": "This section will be populated shortly.",
+      "createAction": "Create item"
     }
   },
   "auth": {

--- a/src/i18n/resources/en.json
+++ b/src/i18n/resources/en.json
@@ -4,6 +4,13 @@
     "loading": "Loading…",
     "welcome": "Welcome to WalletWiz."
   },
+  "pages": {
+    "common": {
+      "empty": "Content coming soon.",
+      "noSession": "No active session.",
+      "sessionBound": "Data bound to session: {{id}}"
+    }
+  },
   "auth": {
     "login": "Sign in",
     "signup": "Create an account",

--- a/src/i18n/resources/fr.json
+++ b/src/i18n/resources/fr.json
@@ -4,6 +4,13 @@
     "loading": "Chargement…",
     "welcome": "Bienvenue dans WalletWiz."
   },
+  "pages": {
+    "common": {
+      "empty": "Contenu à venir.",
+      "noSession": "Aucune session active.",
+      "sessionBound": "Données liées à la session : {{id}}"
+    }
+  },
   "auth": {
     "login": "Se connecter",
     "signup": "Créer un compte",

--- a/src/i18n/resources/fr.json
+++ b/src/i18n/resources/fr.json
@@ -8,7 +8,10 @@
     "common": {
       "empty": "Contenu à venir.",
       "noSession": "Aucune session active.",
-      "sessionBound": "Données liées à la session : {{id}}"
+      "sessionBound": "Données liées à la session : {{id}}",
+      "emptyTitle": "Contenu à venir",
+      "emptyDesc": "Cette section sera bientôt alimentée.",
+      "createAction": "Créer un élément"
     }
   },
   "auth": {

--- a/src/i18n/resources/fr.json
+++ b/src/i18n/resources/fr.json
@@ -21,7 +21,10 @@
     "budgets": "Budgets",
     "settings": "Paramètres",
     "signup": "Inscrivez-vous",
-    "login": "Connectez-vous"
+    "login": "Connectez-vous",
+     "home": "Accueil",
+    "transactions": "Transactions",
+    "sessions": "Sessions"
   },
   "settings": {
     "language": "Langue",

--- a/src/layouts/AppLayout.tsx
+++ b/src/layouts/AppLayout.tsx
@@ -6,11 +6,13 @@ import LanguageSwitcher from "@/i18n/components/settings/LanguageSwitcher";
 import ThemeToggle from "@/components/theme/ThemeToggle";
 import { useAuthStore } from "@/stores/authStore";
 import { useState } from "react";
+import { useSessionsBootstrap } from "@/hooks/useSessionsBootstrap";
 
 export default function AppLayout() {
   const navigate = useNavigate();
   const [mobileOpen, setMobileOpen] = useState(false);
   const logout = useAuthStore((s) => s.logout);
+  useSessionsBootstrap();
 
   return (
     <div className="min-h-dvh grid md:grid-cols-[240px_1fr] overflow-x-hidden">

--- a/src/pages/banks/index.tsx
+++ b/src/pages/banks/index.tsx
@@ -1,20 +1,26 @@
 import { useTranslation } from "react-i18next";
 import { useSessionStore } from "@/stores/sessionStore";
+import PageHeader from "@/components/system/PageHeader";
+import EmptyState from "@/components/system/EmptyState";
 
 export default function BanksPage() {
   const { t } = useTranslation();
   const { currentSessionId } = useSessionStore();
+
   return (
-    <section className="space-y-2">
-      <h1 className="text-2xl font-semibold">{t("nav.banks")}</h1>
-      <p className="text-sm text-muted-foreground">
-        {currentSessionId
-          ? t("pages.common.sessionBound", { id: currentSessionId })
-          : t("pages.common.noSession")}
-      </p>
-      <div className="rounded-lg border p-6 text-sm text-muted-foreground">
-        {t("pages.common.empty")}
-      </div>
+    <section className="p-3 sm:p-4 lg:p-6 space-y-3 sm:space-y-4 lg:space-y-6">
+      <PageHeader
+        title={t("nav.banks")}
+        description={
+          currentSessionId
+            ? t("pages.common.sessionBound", { id: currentSessionId })
+            : t("pages.common.noSession")
+        }
+      />
+      <EmptyState
+        title={t("pages.common.emptyTitle")}
+        description={t("pages.common.emptyDesc")}
+      />
     </section>
   );
 }

--- a/src/pages/banks/index.tsx
+++ b/src/pages/banks/index.tsx
@@ -1,13 +1,12 @@
 import { useTranslation } from "react-i18next";
 import { useSessionStore } from "@/stores/sessionStore";
 
-export default function DashboardHome() {
+export default function BanksPage() {
   const { t } = useTranslation();
   const { currentSessionId } = useSessionStore();
-
   return (
     <section className="space-y-2">
-      <h1 className="text-2xl font-semibold">{t("nav.home")}</h1>
+      <h1 className="text-2xl font-semibold">{t("nav.banks")}</h1>
       <p className="text-sm text-muted-foreground">
         {currentSessionId
           ? t("pages.common.sessionBound", { id: currentSessionId })

--- a/src/pages/budgets/index.tsx
+++ b/src/pages/budgets/index.tsx
@@ -1,13 +1,12 @@
 import { useTranslation } from "react-i18next";
 import { useSessionStore } from "@/stores/sessionStore";
 
-export default function DashboardHome() {
+export default function BudgetsPage() {
   const { t } = useTranslation();
   const { currentSessionId } = useSessionStore();
-
   return (
     <section className="space-y-2">
-      <h1 className="text-2xl font-semibold">{t("nav.home")}</h1>
+      <h1 className="text-2xl font-semibold">{t("nav.budgets")}</h1>
       <p className="text-sm text-muted-foreground">
         {currentSessionId
           ? t("pages.common.sessionBound", { id: currentSessionId })

--- a/src/pages/budgets/index.tsx
+++ b/src/pages/budgets/index.tsx
@@ -1,20 +1,25 @@
 import { useTranslation } from "react-i18next";
 import { useSessionStore } from "@/stores/sessionStore";
+import PageHeader from "@/components/system/PageHeader";
+import EmptyState from "@/components/system/EmptyState";
 
 export default function BudgetsPage() {
   const { t } = useTranslation();
   const { currentSessionId } = useSessionStore();
   return (
-    <section className="space-y-2">
-      <h1 className="text-2xl font-semibold">{t("nav.budgets")}</h1>
-      <p className="text-sm text-muted-foreground">
-        {currentSessionId
-          ? t("pages.common.sessionBound", { id: currentSessionId })
-          : t("pages.common.noSession")}
-      </p>
-      <div className="rounded-lg border p-6 text-sm text-muted-foreground">
-        {t("pages.common.empty")}
-      </div>
+    <section className="p-3 sm:p-4 lg:p-6 space-y-3 sm:space-y-4 lg:space-y-6">
+      <PageHeader
+        title={t("nav.budgets")}
+        description={
+          currentSessionId
+            ? t("pages.common.sessionBound", { id: currentSessionId })
+            : t("pages.common.noSession")
+        }
+      />
+      <EmptyState
+        title={t("pages.common.emptyTitle")}
+        description={t("pages.common.emptyDesc")}
+      />
     </section>
   );
 }

--- a/src/pages/dashboard/NotFound.tsx
+++ b/src/pages/dashboard/NotFound.tsx
@@ -1,0 +1,15 @@
+import { Link } from "react-router-dom";
+
+export default function DashboardNotFound() {
+  return (
+    <div className="p-3 sm:p-6 space-y-2 text-sm">
+      <div className="text-base sm:text-lg font-medium">Page introuvable</div>
+      <div className="text-muted-foreground">
+        Vérifie l’URL ou reviens à l’accueil du tableau de bord.
+      </div>
+      <Link to="/dashboard/home" className="text-primary underline underline-offset-4">
+        Retour au dashboard
+      </Link>
+    </div>
+  );
+}

--- a/src/pages/dashboard/home.tsx
+++ b/src/pages/dashboard/home.tsx
@@ -1,21 +1,26 @@
 import { useTranslation } from "react-i18next";
 import { useSessionStore } from "@/stores/sessionStore";
+import PageHeader from "@/components/system/PageHeader";
+import EmptyState from "@/components/system/EmptyState";
 
 export default function DashboardHome() {
   const { t } = useTranslation();
   const { currentSessionId } = useSessionStore();
 
   return (
-    <section className="space-y-2">
-      <h1 className="text-2xl font-semibold">{t("nav.home")}</h1>
-      <p className="text-sm text-muted-foreground">
-        {currentSessionId
-          ? t("pages.common.sessionBound", { id: currentSessionId })
-          : t("pages.common.noSession")}
-      </p>
-      <div className="rounded-lg border p-6 text-sm text-muted-foreground">
-        {t("pages.common.empty")}
-      </div>
+    <section className="p-3 sm:p-4 lg:p-6 space-y-3 sm:space-y-4 lg:space-y-6">
+      <PageHeader
+        title={t("nav.home")}
+        description={
+          currentSessionId
+            ? t("pages.common.sessionBound", { id: currentSessionId })
+            : t("pages.common.noSession")
+        }
+      />
+      <EmptyState
+        title={t("pages.common.emptyTitle")}
+        description={t("pages.common.emptyDesc")}
+      />
     </section>
   );
 }

--- a/src/pages/expenses/index.tsx
+++ b/src/pages/expenses/index.tsx
@@ -1,20 +1,25 @@
 import { useTranslation } from "react-i18next";
 import { useSessionStore } from "@/stores/sessionStore";
+import PageHeader from "@/components/system/PageHeader";
+import EmptyState from "@/components/system/EmptyState";
 
 export default function ExpensesPage() {
   const { t } = useTranslation();
   const { currentSessionId } = useSessionStore();
   return (
-    <section className="space-y-2">
-      <h1 className="text-2xl font-semibold">{t("nav.expenses")}</h1>
-      <p className="text-sm text-muted-foreground">
-        {currentSessionId
-          ? t("pages.common.sessionBound", { id: currentSessionId })
-          : t("pages.common.noSession")}
-      </p>
-      <div className="rounded-lg border p-6 text-sm text-muted-foreground">
-        {t("pages.common.empty")}
-      </div>
+    <section className="p-3 sm:p-4 lg:p-6 space-y-3 sm:space-y-4 lg:space-y-6">
+      <PageHeader
+        title={t("nav.expenses")}
+        description={
+          currentSessionId
+            ? t("pages.common.sessionBound", { id: currentSessionId })
+            : t("pages.common.noSession")
+        }
+      />
+      <EmptyState
+        title={t("pages.common.emptyTitle")}
+        description={t("pages.common.emptyDesc")}
+      />
     </section>
   );
 }

--- a/src/pages/expenses/index.tsx
+++ b/src/pages/expenses/index.tsx
@@ -1,13 +1,12 @@
 import { useTranslation } from "react-i18next";
 import { useSessionStore } from "@/stores/sessionStore";
 
-export default function DashboardHome() {
+export default function ExpensesPage() {
   const { t } = useTranslation();
   const { currentSessionId } = useSessionStore();
-
   return (
     <section className="space-y-2">
-      <h1 className="text-2xl font-semibold">{t("nav.home")}</h1>
+      <h1 className="text-2xl font-semibold">{t("nav.expenses")}</h1>
       <p className="text-sm text-muted-foreground">
         {currentSessionId
           ? t("pages.common.sessionBound", { id: currentSessionId })

--- a/src/pages/incomes/index.tsx
+++ b/src/pages/incomes/index.tsx
@@ -1,13 +1,12 @@
 import { useTranslation } from "react-i18next";
 import { useSessionStore } from "@/stores/sessionStore";
 
-export default function DashboardHome() {
+export default function IncomesPage() {
   const { t } = useTranslation();
   const { currentSessionId } = useSessionStore();
-
   return (
     <section className="space-y-2">
-      <h1 className="text-2xl font-semibold">{t("nav.home")}</h1>
+      <h1 className="text-2xl font-semibold">{t("nav.incomes")}</h1>
       <p className="text-sm text-muted-foreground">
         {currentSessionId
           ? t("pages.common.sessionBound", { id: currentSessionId })

--- a/src/pages/incomes/index.tsx
+++ b/src/pages/incomes/index.tsx
@@ -1,20 +1,26 @@
 import { useTranslation } from "react-i18next";
 import { useSessionStore } from "@/stores/sessionStore";
+import PageHeader from "@/components/system/PageHeader";
+import EmptyState from "@/components/system/EmptyState";
 
 export default function IncomesPage() {
   const { t } = useTranslation();
   const { currentSessionId } = useSessionStore();
   return (
-    <section className="space-y-2">
-      <h1 className="text-2xl font-semibold">{t("nav.incomes")}</h1>
-      <p className="text-sm text-muted-foreground">
-        {currentSessionId
-          ? t("pages.common.sessionBound", { id: currentSessionId })
-          : t("pages.common.noSession")}
-      </p>
-      <div className="rounded-lg border p-6 text-sm text-muted-foreground">
-        {t("pages.common.empty")}
-      </div>
+    <section className="p-3 sm:p-4 lg:p-6 space-y-3 sm:space-y-4 lg:space-y-6">
+      <PageHeader
+        title={t("nav.incomes")}
+        description={
+          currentSessionId
+            ? t("pages.common.sessionBound", { id: currentSessionId })
+            : t("pages.common.noSession")
+        }
+      />
+      <EmptyState
+        title={t("pages.common.emptyTitle")}
+        description={t("pages.common.emptyDesc")}
+      />
     </section>
   );
 }
+

--- a/src/pages/members/index.tsx
+++ b/src/pages/members/index.tsx
@@ -1,20 +1,25 @@
 import { useTranslation } from "react-i18next";
 import { useSessionStore } from "@/stores/sessionStore";
+import PageHeader from "@/components/system/PageHeader";
+import EmptyState from "@/components/system/EmptyState";
 
 export default function MembersPage() {
   const { t } = useTranslation();
   const { currentSessionId } = useSessionStore();
   return (
-    <section className="space-y-2">
-      <h1 className="text-2xl font-semibold">{t("nav.members")}</h1>
-      <p className="text-sm text-muted-foreground">
-        {currentSessionId
-          ? t("pages.common.sessionBound", { id: currentSessionId })
-          : t("pages.common.noSession")}
-      </p>
-      <div className="rounded-lg border p-6 text-sm text-muted-foreground">
-        {t("pages.common.empty")}
-      </div>
+    <section className="p-3 sm:p-4 lg:p-6 space-y-3 sm:space-y-4 lg:space-y-6">
+      <PageHeader
+        title={t("nav.members")}
+        description={
+          currentSessionId
+            ? t("pages.common.sessionBound", { id: currentSessionId })
+            : t("pages.common.noSession")
+        }
+      />
+      <EmptyState
+        title={t("pages.common.emptyTitle")}
+        description={t("pages.common.emptyDesc")}
+      />
     </section>
   );
 }

--- a/src/pages/members/index.tsx
+++ b/src/pages/members/index.tsx
@@ -1,13 +1,12 @@
 import { useTranslation } from "react-i18next";
 import { useSessionStore } from "@/stores/sessionStore";
 
-export default function DashboardHome() {
+export default function MembersPage() {
   const { t } = useTranslation();
   const { currentSessionId } = useSessionStore();
-
   return (
     <section className="space-y-2">
-      <h1 className="text-2xl font-semibold">{t("nav.home")}</h1>
+      <h1 className="text-2xl font-semibold">{t("nav.members")}</h1>
       <p className="text-sm text-muted-foreground">
         {currentSessionId
           ? t("pages.common.sessionBound", { id: currentSessionId })

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -1,13 +1,19 @@
 import { useTranslation } from "react-i18next";
+import PageHeader from "@/components/system/PageHeader";
+import EmptyState from "@/components/system/EmptyState";
 
 export default function ProfilePage() {
   const { t } = useTranslation();
   return (
-    <section className="space-y-2">
-      <h1 className="text-2xl font-semibold">{t("nav.profile")}</h1>
-      <div className="rounded-lg border p-6 text-sm text-muted-foreground">
-        {t("pages.common.empty")}
-      </div>
+    <section className="p-3 sm:p-4 lg:p-6 space-y-3 sm:space-y-4 lg:space-y-6">
+      <PageHeader
+        title={t("nav.profile")}
+        description={t("pages.common.noSession")}
+      />
+      <EmptyState
+        title={t("pages.common.emptyTitle")}
+        description={t("pages.common.emptyDesc")}
+      />
     </section>
   );
 }

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -1,0 +1,13 @@
+import { useTranslation } from "react-i18next";
+
+export default function ProfilePage() {
+  const { t } = useTranslation();
+  return (
+    <section className="space-y-2">
+      <h1 className="text-2xl font-semibold">{t("nav.profile")}</h1>
+      <div className="rounded-lg border p-6 text-sm text-muted-foreground">
+        {t("pages.common.empty")}
+      </div>
+    </section>
+  );
+}

--- a/src/pages/settings/SessionSettingsPage.tsx
+++ b/src/pages/settings/SessionSettingsPage.tsx
@@ -72,7 +72,7 @@ export default function SessionSettingsPage() {
   }
 
   return (
-    <div className="space-y-6">
+    <div className="p-3 sm:p-4 lg:p-6 space-y-3 sm:space-y-4 lg:space-y-6">
       <div>
         <h1 className="text-2xl font-semibold">{t("sessions.settings.title")}</h1>
         <p className="text-sm text-muted-foreground">{t("sessions.settings.subtitle")}</p>

--- a/src/pages/transactions/index.tsx
+++ b/src/pages/transactions/index.tsx
@@ -1,13 +1,12 @@
 import { useTranslation } from "react-i18next";
 import { useSessionStore } from "@/stores/sessionStore";
 
-export default function DashboardHome() {
+export default function TransactionsPage() {
   const { t } = useTranslation();
   const { currentSessionId } = useSessionStore();
-
   return (
     <section className="space-y-2">
-      <h1 className="text-2xl font-semibold">{t("nav.home")}</h1>
+      <h1 className="text-2xl font-semibold">{t("nav.transactions")}</h1>
       <p className="text-sm text-muted-foreground">
         {currentSessionId
           ? t("pages.common.sessionBound", { id: currentSessionId })

--- a/src/pages/transactions/index.tsx
+++ b/src/pages/transactions/index.tsx
@@ -1,20 +1,25 @@
 import { useTranslation } from "react-i18next";
 import { useSessionStore } from "@/stores/sessionStore";
+import PageHeader from "@/components/system/PageHeader";
+import EmptyState from "@/components/system/EmptyState";
 
 export default function TransactionsPage() {
   const { t } = useTranslation();
   const { currentSessionId } = useSessionStore();
   return (
-    <section className="space-y-2">
-      <h1 className="text-2xl font-semibold">{t("nav.transactions")}</h1>
-      <p className="text-sm text-muted-foreground">
-        {currentSessionId
-          ? t("pages.common.sessionBound", { id: currentSessionId })
-          : t("pages.common.noSession")}
-      </p>
-      <div className="rounded-lg border p-6 text-sm text-muted-foreground">
-        {t("pages.common.empty")}
-      </div>
+    <section className="p-3 sm:p-4 lg:p-6 space-y-3 sm:space-y-4 lg:space-y-6">
+      <PageHeader
+        title={t("nav.transactions")}
+        description={
+          currentSessionId
+            ? t("pages.common.sessionBound", { id: currentSessionId })
+            : t("pages.common.noSession")
+        }
+      />
+      <EmptyState
+        title={t("pages.common.emptyTitle")}
+        description={t("pages.common.emptyDesc")}
+      />
     </section>
   );
 }

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -4,12 +4,14 @@ import AuthGuard from "./AuthGuard";
 import PublicRoute from "./PublicRoute";
 import AppLayout from "@/layouts/AppLayout";
 import AuthLayout from "@/layouts/AuthLayout";
+import PageSkeleton from "@/components/system/PageSkeleton";
 
 // Pages (placeholders si besoin)
 import LoginPage from "@/pages/login";
 import SignupPage from "@/pages/signup";
 import DashboardHome from "@/pages/dashboard/home";
 import SessionSettingsPage from "@/pages/settings/SessionSettingsPage";
+import DashboardNotFound from "@/pages/dashboard/NotFound";
 
 const BanksPage = lazy(() => import("@/pages/banks"));
 const MembersPage = lazy(() => import("@/pages/members"));
@@ -18,10 +20,6 @@ const ExpensesPage = lazy(() => import("@/pages/expenses"));
 const BudgetsPage = lazy(() => import("@/pages/budgets"));
 const TransactionsPage = lazy(() => import("@/pages/transactions"));
 const ProfilePage = lazy(() => import("@/pages/profile"));
-
-function Fallback() {
-  return <div className="p-6 text-sm text-muted-foreground">Chargement…</div>;
-}
 
 export default function AppRouter() {
   return (
@@ -44,7 +42,7 @@ export default function AppRouter() {
             <Route
               path="/dashboard/banks"
               element={
-                <Suspense fallback={<Fallback />}>
+                <Suspense fallback={<PageSkeleton />}>
                   <BanksPage />
                 </Suspense>
               }
@@ -52,7 +50,7 @@ export default function AppRouter() {
             <Route
               path="/dashboard/members"
               element={
-                <Suspense fallback={<Fallback />}>
+                <Suspense fallback={<PageSkeleton />}>
                   <MembersPage />
                 </Suspense>
               }
@@ -60,7 +58,7 @@ export default function AppRouter() {
             <Route
               path="/dashboard/incomes"
               element={
-                <Suspense fallback={<Fallback />}>
+                <Suspense fallback={<PageSkeleton />}>
                   <IncomesPage />
                 </Suspense>
               }
@@ -68,7 +66,7 @@ export default function AppRouter() {
             <Route
               path="/dashboard/expenses"
               element={
-                <Suspense fallback={<Fallback />}>
+                <Suspense fallback={<PageSkeleton />}>
                   <ExpensesPage />
                 </Suspense>
               }
@@ -76,7 +74,7 @@ export default function AppRouter() {
             <Route
               path="/dashboard/budgets"
               element={
-                <Suspense fallback={<Fallback />}>
+                <Suspense fallback={<PageSkeleton />}>
                   <BudgetsPage />
                 </Suspense>
               }
@@ -84,7 +82,7 @@ export default function AppRouter() {
             <Route
               path="/dashboard/transactions"
               element={
-                <Suspense fallback={<Fallback />}>
+                <Suspense fallback={<PageSkeleton />}>
                   <TransactionsPage />
                 </Suspense>
               }
@@ -92,7 +90,7 @@ export default function AppRouter() {
             <Route
               path="/dashboard/settings/profile"
               element={
-                <Suspense fallback={<Fallback />}>
+                <Suspense fallback={<PageSkeleton />}>
                   <ProfilePage />
                 </Suspense>
               }
@@ -103,6 +101,7 @@ export default function AppRouter() {
 
             {/* réglages sessions (existant) */}
             <Route path="/dashboard/settings/session" element={<SessionSettingsPage />} />
+            <Route path="/dashboard/*" element={<DashboardNotFound />} />
           </Route>
         </Route>
 

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,4 +1,5 @@
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
+import { lazy, Suspense } from "react";
 import AuthGuard from "./AuthGuard";
 import PublicRoute from "./PublicRoute";
 import AppLayout from "@/layouts/AppLayout";
@@ -9,6 +10,18 @@ import LoginPage from "@/pages/login";
 import SignupPage from "@/pages/signup";
 import DashboardHome from "@/pages/dashboard/home";
 import SessionSettingsPage from "@/pages/settings/SessionSettingsPage";
+
+const BanksPage = lazy(() => import("@/pages/banks"));
+const MembersPage = lazy(() => import("@/pages/members"));
+const IncomesPage = lazy(() => import("@/pages/incomes"));
+const ExpensesPage = lazy(() => import("@/pages/expenses"));
+const BudgetsPage = lazy(() => import("@/pages/budgets"));
+const TransactionsPage = lazy(() => import("@/pages/transactions"));
+const ProfilePage = lazy(() => import("@/pages/profile"));
+
+function Fallback() {
+  return <div className="p-6 text-sm text-muted-foreground">Chargement…</div>;
+}
 
 export default function AppRouter() {
   return (
@@ -26,8 +39,69 @@ export default function AppRouter() {
         <Route element={<AuthGuard />}>
           <Route element={<AppLayout />}>
             <Route path="/dashboard/home" element={<DashboardHome />} />
-            {/* Tu ajouteras ici: /dashboard/profile, /members, /banks, etc. */}
+
+            {/* Pages J3 en lazy */}
+            <Route
+              path="/dashboard/banks"
+              element={
+                <Suspense fallback={<Fallback />}>
+                  <BanksPage />
+                </Suspense>
+              }
+            />
+            <Route
+              path="/dashboard/members"
+              element={
+                <Suspense fallback={<Fallback />}>
+                  <MembersPage />
+                </Suspense>
+              }
+            />
+            <Route
+              path="/dashboard/incomes"
+              element={
+                <Suspense fallback={<Fallback />}>
+                  <IncomesPage />
+                </Suspense>
+              }
+            />
+            <Route
+              path="/dashboard/expenses"
+              element={
+                <Suspense fallback={<Fallback />}>
+                  <ExpensesPage />
+                </Suspense>
+              }
+            />
+            <Route
+              path="/dashboard/budgets"
+              element={
+                <Suspense fallback={<Fallback />}>
+                  <BudgetsPage />
+                </Suspense>
+              }
+            />
+            <Route
+              path="/dashboard/transactions"
+              element={
+                <Suspense fallback={<Fallback />}>
+                  <TransactionsPage />
+                </Suspense>
+              }
+            />
+            <Route
+              path="/dashboard/settings/profile"
+              element={
+                <Suspense fallback={<Fallback />}>
+                  <ProfilePage />
+                </Suspense>
+              }
+            />
+
+            {/* redirection dossier dashboard */}
             <Route path="/dashboard" element={<Navigate to="/dashboard/home" replace />} />
+
+            {/* réglages sessions (existant) */}
             <Route path="/dashboard/settings/session" element={<SessionSettingsPage />} />
           </Route>
         </Route>


### PR DESCRIPTION
Stabilise la navigation du dashboard et prépare toutes les pages vides (lazy) prêtes à consommer currentSessionId.
Inclus : config nav centralisée, bootstrap des sessions en AppLayout, routes privées lazy, pages vides (Banks/Members/Incomes/Expenses/Budgets/Transactions/Profile), composants système (PageSkeleton, PageHeader, EmptyState) et 404 interne du dashboard.