### PR TITLE
feat(j5-members): members management with invite-link, roles guard, revoke/remove, public invite pages + responsive

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-slot": "^1.2.3",
         "@radix-ui/react-switch": "^1.2.6",
+        "@radix-ui/react-tabs": "^1.1.13",
         "@tailwindcss/vite": "^4.1.12",
         "axios": "^1.11.0",
         "class-variance-authority": "^0.7.1",
@@ -1489,6 +1490,37 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.11.tgz",
+      "integrity": "sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-select": {
       "version": "2.2.6",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.2.6.tgz",
@@ -1563,6 +1595,36 @@
         "@radix-ui/react-use-controllable-state": "1.2.2",
         "@radix-ui/react-use-previous": "1.1.1",
         "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.13.tgz",
+      "integrity": "sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-switch": "^1.2.6",
+    "@radix-ui/react-tabs": "^1.1.13",
     "@tailwindcss/vite": "^4.1.12",
     "axios": "^1.11.0",
     "class-variance-authority": "^0.7.1",

--- a/src/components/members/InviteDialog.tsx
+++ b/src/components/members/InviteDialog.tsx
@@ -77,14 +77,14 @@ export default function InviteDialog({ open, onOpenChange }: Props) {
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent>
+      <DialogContent className="sm:max-w-lg max-w-[calc(100vw-1.5rem)]">
         <DialogHeader>
           <DialogTitle>{t("members.invite.title")}</DialogTitle>
           <DialogDescription>{t("members.invite.desc")}</DialogDescription>
         </DialogHeader>
 
         <Tabs value={tab} onValueChange={(v) => setTab(v as any)}>
-          <TabsList className="grid grid-cols-3">
+          <TabsList className="w-full grid grid-cols-3 gap-1 text-xs sm:text-sm">
             <TabsTrigger value="existing">{t("members.form.tabs.existing")}</TabsTrigger>
             <TabsTrigger value="placeholder">{t("members.form.tabs.placeholder")}</TabsTrigger>
             <TabsTrigger value="link">{t("members.form.tabs.link")}</TabsTrigger>
@@ -94,13 +94,13 @@ export default function InviteDialog({ open, onOpenChange }: Props) {
           <TabsContent value="existing" className="space-y-4 mt-4">
             <div className="space-y-2">
               <label className="text-sm font-medium">{t("members.form.userId")}</label>
-              <Input value={userId} onChange={(e) => setUserId(e.target.value)} placeholder="usr_..." />
+              <Input className="h-9 text-xs sm:text-sm" value={userId} onChange={(e) => setUserId(e.target.value)} placeholder="ID de l'utilisateur" />
             </div>
 
             <div className="space-y-2">
               <label className="text-sm font-medium">{t("members.form.role")}</label>
               <Select value={role} onValueChange={(v) => setRole(v as any)}>
-                <SelectTrigger><SelectValue /></SelectTrigger>
+                <SelectTrigger className="h-9 w-full"><SelectValue /></SelectTrigger>
                 <SelectContent>
                   <SelectItem value="OWNER">{t("members.roles.owner")}</SelectItem>
                   <SelectItem value="COLLABORATOR">{t("members.roles.collaborator")}</SelectItem>
@@ -109,8 +109,8 @@ export default function InviteDialog({ open, onOpenChange }: Props) {
               </Select>
             </div>
 
-            <DialogFooter>
-              <Button onClick={onInviteExisting}>{t("members.actions.invite")}</Button>
+            <DialogFooter className="flex flex-col sm:flex-row gap-2">
+              <Button className="w-full sm:w-auto" onClick={onInviteExisting}>{t("members.actions.invite")}</Button>
             </DialogFooter>
           </TabsContent>
 
@@ -118,13 +118,13 @@ export default function InviteDialog({ open, onOpenChange }: Props) {
           <TabsContent value="placeholder" className="space-y-4 mt-4">
             <div className="space-y-2">
               <label className="text-sm font-medium">{t("members.form.name")}</label>
-              <Input value={name} onChange={(e) => setName(e.target.value)} placeholder={t("members.form.namePh") ?? ""} />
+              <Input className="h-9 text-xs sm:text-sm" value={name} onChange={(e) => setName(e.target.value)} placeholder={t("members.form.namePh") ?? ""} />
             </div>
 
             <div className="space-y-2">
               <label className="text-sm font-medium">{t("members.form.role")}</label>
               <Select value={role} onValueChange={(v) => setRole(v as any)}>
-                <SelectTrigger><SelectValue /></SelectTrigger>
+                <SelectTrigger className="h-9 w-full"><SelectValue /></SelectTrigger>
                 <SelectContent>
                   <SelectItem value="OWNER">{t("members.roles.owner")}</SelectItem>
                   <SelectItem value="COLLABORATOR">{t("members.roles.collaborator")}</SelectItem>
@@ -133,8 +133,8 @@ export default function InviteDialog({ open, onOpenChange }: Props) {
               </Select>
             </div>
 
-            <DialogFooter>
-              <Button onClick={onInvitePlaceholder}>{t("members.actions.invite")}</Button>
+            <DialogFooter className="flex flex-col sm:flex-row gap-2">
+              <Button className="w-full sm:w-auto" onClick={onInvitePlaceholder}>{t("members.actions.invite")}</Button>
             </DialogFooter>
           </TabsContent>
 
@@ -143,7 +143,7 @@ export default function InviteDialog({ open, onOpenChange }: Props) {
             <div className="space-y-2">
               <label className="text-sm font-medium">{t("members.form.role")}</label>
               <Select value={role} onValueChange={(v) => setRole(v as any)}>
-                <SelectTrigger><SelectValue /></SelectTrigger>
+                <SelectTrigger className="h-9 w-full"><SelectValue /></SelectTrigger>
                 <SelectContent>
                   <SelectItem value="OWNER">{t("members.roles.owner")}</SelectItem>
                   <SelectItem value="COLLABORATOR">{t("members.roles.collaborator")}</SelectItem>
@@ -154,20 +154,20 @@ export default function InviteDialog({ open, onOpenChange }: Props) {
 
             <div className="space-y-2">
               <label className="text-sm font-medium">{t("members.form.emailMemo")}</label>
-              <Input value={emailMemo} onChange={(e) => setEmailMemo(e.target.value)} placeholder="(optionnel)" />
+              <Input className="h-9 text-xs sm:text-sm" value={emailMemo} onChange={(e) => setEmailMemo(e.target.value)} placeholder="exemple@walletwiz.fr" />
               <p className="text-xs text-muted-foreground">{t("members.form.emailMemoHint")}</p>
             </div>
 
             {shareLink ? (
               <div className="rounded-md border p-3 space-y-2">
                 <div className="text-sm font-medium">{t("members.share.title")}</div>
-                <div className="text-xs break-all">{shareLink}</div>
-                <div className="flex gap-2 pt-1">
-                  <Button variant="secondary" onClick={copyLink}>
+                <div className="text-xs break-words">{shareLink}</div>
+                <div className="flex flex-col sm:flex-row gap-2 pt-1">
+                  <Button className="w-full sm:w-auto" variant="secondary" onClick={copyLink}>
                     <Copy className="h-4 w-4 mr-2" /> {t("members.share.copy")}
                   </Button>
                   <a href={shareLink} target="_blank" rel="noreferrer">
-                    <Button variant="outline">
+                    <Button className="w-full sm:w-auto" variant="outline">
                       <ExternalLink className="h-4 w-4 mr-2" /> {t("members.share.open")}
                     </Button>
                   </a>
@@ -175,8 +175,8 @@ export default function InviteDialog({ open, onOpenChange }: Props) {
               </div>
             ) : null}
 
-            <DialogFooter>
-              <Button onClick={onInviteLink}>{t("members.actions.generateLink")}</Button>
+            <DialogFooter className="flex flex-col sm:flex-row gap-2">
+              <Button className="w-full sm:w-auto" onClick={onInviteLink}>{t("members.actions.generateLink")}</Button>
             </DialogFooter>
           </TabsContent>
         </Tabs>

--- a/src/components/members/InviteDialog.tsx
+++ b/src/components/members/InviteDialog.tsx
@@ -1,0 +1,186 @@
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Tabs, TabsList, TabsTrigger, TabsContent
+} from "@/components/ui/tabs";
+import {
+  Select, SelectTrigger, SelectValue, SelectContent, SelectItem
+} from "@/components/ui/select";
+import { useMembers } from "@/hooks/useMembers";
+import { Copy, ExternalLink } from "lucide-react";
+
+type Props = {
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+};
+
+export default function InviteDialog({ open, onOpenChange }: Props) {
+  const { t } = useTranslation();
+  const {
+    inviteExisting, invitePlaceholder, inviteWithLink,
+  } = useMembers();
+
+  const [tab, setTab] = useState<"existing" | "placeholder" | "link">("link");
+  const [role, setRole] = useState<"OWNER" | "COLLABORATOR" | "VIEWER">("VIEWER");
+
+  // forms
+  const [userId, setUserId] = useState("");
+  const [name, setName] = useState("");
+  const [emailMemo, setEmailMemo] = useState("");
+  const [shareLink, setShareLink] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    if (!open) {
+      setTab("link");
+      setRole("VIEWER");
+      setUserId("");
+      setName("");
+      setEmailMemo("");
+      setShareLink(undefined);
+    }
+  }, [open]);
+
+  async function onInviteExisting() {
+    if (!userId.trim()) return toast.error(t("members.form.userIdRequired"));
+    await inviteExisting(userId.trim(), role);
+    toast.success(t("members.toasts.invited"));
+    onOpenChange(false);
+  }
+
+  async function onInvitePlaceholder() {
+    if (!name.trim()) return toast.error(t("members.form.nameRequired"));
+    await invitePlaceholder(name.trim(), role);
+    toast.success(t("members.toasts.invited"));
+    onOpenChange(false);
+  }
+
+  async function onInviteLink() {
+    const link = await inviteWithLink(role, emailMemo.trim() || undefined);
+    if (!link) {
+      toast.error(t("members.toasts.noToken"));
+      return;
+    }
+    setShareLink(link);
+    toast.success(t("members.toasts.invited"));
+  }
+
+  function copyLink() {
+    if (!shareLink) return;
+    navigator.clipboard.writeText(shareLink).then(() => {
+      toast.success(t("members.share.copied"));
+    });
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{t("members.invite.title")}</DialogTitle>
+          <DialogDescription>{t("members.invite.desc")}</DialogDescription>
+        </DialogHeader>
+
+        <Tabs value={tab} onValueChange={(v) => setTab(v as any)}>
+          <TabsList className="grid grid-cols-3">
+            <TabsTrigger value="existing">{t("members.form.tabs.existing")}</TabsTrigger>
+            <TabsTrigger value="placeholder">{t("members.form.tabs.placeholder")}</TabsTrigger>
+            <TabsTrigger value="link">{t("members.form.tabs.link")}</TabsTrigger>
+          </TabsList>
+
+          {/* EXISTING */}
+          <TabsContent value="existing" className="space-y-4 mt-4">
+            <div className="space-y-2">
+              <label className="text-sm font-medium">{t("members.form.userId")}</label>
+              <Input value={userId} onChange={(e) => setUserId(e.target.value)} placeholder="usr_..." />
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium">{t("members.form.role")}</label>
+              <Select value={role} onValueChange={(v) => setRole(v as any)}>
+                <SelectTrigger><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="OWNER">{t("members.roles.owner")}</SelectItem>
+                  <SelectItem value="COLLABORATOR">{t("members.roles.collaborator")}</SelectItem>
+                  <SelectItem value="VIEWER">{t("members.roles.viewer")}</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            <DialogFooter>
+              <Button onClick={onInviteExisting}>{t("members.actions.invite")}</Button>
+            </DialogFooter>
+          </TabsContent>
+
+          {/* PLACEHOLDER */}
+          <TabsContent value="placeholder" className="space-y-4 mt-4">
+            <div className="space-y-2">
+              <label className="text-sm font-medium">{t("members.form.name")}</label>
+              <Input value={name} onChange={(e) => setName(e.target.value)} placeholder={t("members.form.namePh") ?? ""} />
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium">{t("members.form.role")}</label>
+              <Select value={role} onValueChange={(v) => setRole(v as any)}>
+                <SelectTrigger><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="OWNER">{t("members.roles.owner")}</SelectItem>
+                  <SelectItem value="COLLABORATOR">{t("members.roles.collaborator")}</SelectItem>
+                  <SelectItem value="VIEWER">{t("members.roles.viewer")}</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            <DialogFooter>
+              <Button onClick={onInvitePlaceholder}>{t("members.actions.invite")}</Button>
+            </DialogFooter>
+          </TabsContent>
+
+          {/* LINK */}
+          <TabsContent value="link" className="space-y-4 mt-4">
+            <div className="space-y-2">
+              <label className="text-sm font-medium">{t("members.form.role")}</label>
+              <Select value={role} onValueChange={(v) => setRole(v as any)}>
+                <SelectTrigger><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="OWNER">{t("members.roles.owner")}</SelectItem>
+                  <SelectItem value="COLLABORATOR">{t("members.roles.collaborator")}</SelectItem>
+                  <SelectItem value="VIEWER">{t("members.roles.viewer")}</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium">{t("members.form.emailMemo")}</label>
+              <Input value={emailMemo} onChange={(e) => setEmailMemo(e.target.value)} placeholder="(optionnel)" />
+              <p className="text-xs text-muted-foreground">{t("members.form.emailMemoHint")}</p>
+            </div>
+
+            {shareLink ? (
+              <div className="rounded-md border p-3 space-y-2">
+                <div className="text-sm font-medium">{t("members.share.title")}</div>
+                <div className="text-xs break-all">{shareLink}</div>
+                <div className="flex gap-2 pt-1">
+                  <Button variant="secondary" onClick={copyLink}>
+                    <Copy className="h-4 w-4 mr-2" /> {t("members.share.copy")}
+                  </Button>
+                  <a href={shareLink} target="_blank" rel="noreferrer">
+                    <Button variant="outline">
+                      <ExternalLink className="h-4 w-4 mr-2" /> {t("members.share.open")}
+                    </Button>
+                  </a>
+                </div>
+              </div>
+            ) : null}
+
+            <DialogFooter>
+              <Button onClick={onInviteLink}>{t("members.actions.generateLink")}</Button>
+            </DialogFooter>
+          </TabsContent>
+        </Tabs>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/members/MemberCardItem.tsx
+++ b/src/components/members/MemberCardItem.tsx
@@ -1,0 +1,73 @@
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Trash2, Link as LinkIcon } from "lucide-react";
+import RoleSelect from "./RoleSelect";
+import type { Member } from "@/types";
+import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
+
+type Props = {
+  member: Member;
+  onRevoke: (id: string) => Promise<void>;
+  onRemove: (id: string) => Promise<void>;
+};
+
+export default function MemberCardItem({ member, onRevoke, onRemove }: Props) {
+  const { t } = useTranslation();
+
+  const display = member.name ?? member.invitedEmail ?? member.userId ?? member.id;
+  const canRevoke = member.invitationStatus === "PENDING";
+  const canRemove = member.invitationStatus === "ACCEPTED";
+  const canCopyLink = !!member.inviteToken && member.invitationStatus === "PENDING";
+
+  function statusBadge(s?: Member["invitationStatus"]) {
+    if (s === "PENDING") return <Badge variant="secondary">{t("members.status.pending")}</Badge>;
+    if (s === "DECLINED") return <Badge variant="destructive">{t("members.status.declined")}</Badge>;
+    return <Badge>{t("members.status.accepted")}</Badge>;
+  }
+
+  return (
+    <Card>
+      <CardContent className="p-3 space-y-3">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <div className="font-medium truncate">{display}</div>
+            <div className="mt-1">{statusBadge(member.invitationStatus)}</div>
+          </div>
+          <div className="w-36">
+            <RoleSelect member={member} />
+          </div>
+        </div>
+
+        <div className="flex flex-col sm:flex-row flex-wrap gap-2">
+          {canCopyLink && (
+            <Button
+              variant="secondary"
+              size="sm"
+              className="w-full sm:w-auto"
+              onClick={() => {
+                const url = `${window.location.origin}/invite/${member.inviteToken}`;
+                navigator.clipboard.writeText(url).then(() => toast.success(t("members.share.copied")));
+              }}
+            >
+              <LinkIcon className="h-4 w-4 mr-2" />
+              {t("members.share.copy")}
+            </Button>
+          )}
+          {canRevoke && (
+            <Button variant="outline" size="sm" className="w-full sm:w-auto" onClick={() => onRevoke(member.id)}>
+              {t("members.actions.revoke")}
+            </Button>
+          )}
+          {canRemove && (
+            <Button variant="destructive" size="sm" className="w-full sm:w-auto" onClick={() => onRemove(member.id)}>
+              <Trash2 className="h-4 w-4 mr-1" />
+              {t("members.actions.remove")}
+            </Button>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/members/RoleSelect.tsx
+++ b/src/components/members/RoleSelect.tsx
@@ -1,0 +1,46 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
+import {
+  Select, SelectTrigger, SelectValue, SelectContent, SelectItem
+} from "@/components/ui/select";
+import { useMembers } from "@/hooks/useMembers";
+import type { Member } from "@/types";
+
+type Props = {
+  member: Member;
+};
+
+export default function RoleSelect({ member }: Props) {
+  const { t } = useTranslation();
+  const { changeMemberRole } = useMembers();
+  const [value, setValue] = useState(member.role);
+
+  async function onChange(next: Member["role"]) {
+    try {
+      setValue(next);
+      await changeMemberRole(member.id, next);
+      toast.success(t("members.toasts.roleChanged"));
+    } catch (e: any) {
+      setValue(member.role);
+      if (e?.message === "lastOwner" || e?.message === "selfLastOwner") {
+        toast.error(t("members.guards.lastOwner"));
+      } else {
+        toast.error(t("members.toasts.errorRole"));
+      }
+    }
+  }
+
+  return (
+    <Select value={value} onValueChange={(v) => onChange(v as any)}>
+      <SelectTrigger className="w-[160px]">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="OWNER">{t("members.roles.owner")}</SelectItem>
+        <SelectItem value="COLLABORATOR">{t("members.roles.collaborator")}</SelectItem>
+        <SelectItem value="VIEWER">{t("members.roles.viewer")}</SelectItem>
+      </SelectContent>
+    </Select>
+  );
+}

--- a/src/components/members/RoleSelect.tsx
+++ b/src/components/members/RoleSelect.tsx
@@ -33,10 +33,10 @@ export default function RoleSelect({ member }: Props) {
 
   return (
     <Select value={value} onValueChange={(v) => onChange(v as any)}>
-      <SelectTrigger className="w-[160px]">
+      <SelectTrigger className="w-full sm:w-[160px] h-9">
         <SelectValue />
       </SelectTrigger>
-      <SelectContent>
+      <SelectContent className="max-h-[60vh]">
         <SelectItem value="OWNER">{t("members.roles.owner")}</SelectItem>
         <SelectItem value="COLLABORATOR">{t("members.roles.collaborator")}</SelectItem>
         <SelectItem value="VIEWER">{t("members.roles.viewer")}</SelectItem>

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -1,0 +1,114 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Table({ className, ...props }: React.ComponentProps<"table">) {
+  return (
+    <div
+      data-slot="table-container"
+      className="relative w-full overflow-x-auto"
+    >
+      <table
+        data-slot="table"
+        className={cn("w-full caption-bottom text-sm", className)}
+        {...props}
+      />
+    </div>
+  )
+}
+
+function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
+  return (
+    <thead
+      data-slot="table-header"
+      className={cn("[&_tr]:border-b", className)}
+      {...props}
+    />
+  )
+}
+
+function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
+  return (
+    <tbody
+      data-slot="table-body"
+      className={cn("[&_tr:last-child]:border-0", className)}
+      {...props}
+    />
+  )
+}
+
+function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
+  return (
+    <tfoot
+      data-slot="table-footer"
+      className={cn(
+        "bg-muted/50 border-t font-medium [&>tr]:last:border-b-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
+  return (
+    <tr
+      data-slot="table-row"
+      className={cn(
+        "hover:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableHead({ className, ...props }: React.ComponentProps<"th">) {
+  return (
+    <th
+      data-slot="table-head"
+      className={cn(
+        "text-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableCell({ className, ...props }: React.ComponentProps<"td">) {
+  return (
+    <td
+      data-slot="table-cell"
+      className={cn(
+        "p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableCaption({
+  className,
+  ...props
+}: React.ComponentProps<"caption">) {
+  return (
+    <caption
+      data-slot="table-caption"
+      className={cn("text-muted-foreground mt-4 text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+}

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,0 +1,64 @@
+import * as React from "react"
+import * as TabsPrimitive from "@radix-ui/react-tabs"
+
+import { cn } from "@/lib/utils"
+
+function Tabs({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Root>) {
+  return (
+    <TabsPrimitive.Root
+      data-slot="tabs"
+      className={cn("flex flex-col gap-2", className)}
+      {...props}
+    />
+  )
+}
+
+function TabsList({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.List>) {
+  return (
+    <TabsPrimitive.List
+      data-slot="tabs-list"
+      className={cn(
+        "bg-muted text-muted-foreground inline-flex h-9 w-fit items-center justify-center rounded-lg p-[3px]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TabsTrigger({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
+  return (
+    <TabsPrimitive.Trigger
+      data-slot="tabs-trigger"
+      className={cn(
+        "data-[state=active]:bg-background dark:data-[state=active]:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 text-foreground dark:text-muted-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TabsContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Content>) {
+  return (
+    <TabsPrimitive.Content
+      data-slot="tabs-content"
+      className={cn("flex-1 outline-none", className)}
+      {...props}
+    />
+  )
+}
+
+export { Tabs, TabsList, TabsTrigger, TabsContent }

--- a/src/hooks/useMembers.ts
+++ b/src/hooks/useMembers.ts
@@ -1,0 +1,153 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useSessionStore } from "@/stores/sessionStore";
+import { useMembersService, makeInviteLink } from "@/lib/service/member.service";
+import type { Member } from "@/types";
+import { useAuthStore } from "@/stores/authStore";
+
+export function useMembers() {
+  const { currentSessionId, membersBySession: map, setMembers } = useSessionStore();
+  const userIdSelf = useAuthStore?.getState?.().user?.id as string | undefined;
+
+  // 🔹 Hooks de service appelés AU TOP-LEVEL (Rules of Hooks)
+  const svc = useMembersService();
+
+  // 🔹 Références STABLES aux fonctions de service (évite deps instables)
+  const listBySessionRef   = useRef(svc.listBySession);
+  const inviteRef          = useRef(svc.invite);
+  const updateRef          = useRef(svc.update);
+  const changeRoleRef      = useRef(svc.changeRole);
+  const revokeInviteRef    = useRef(svc.revokeInvite);
+  const removeRef          = useRef(svc.remove);
+  const getInviteRef       = useRef(svc.getInvite);
+  const acceptInviteRef    = useRef(svc.acceptInvite);
+
+  useEffect(() => {
+    listBySessionRef.current = svc.listBySession;
+    inviteRef.current        = svc.invite;
+    updateRef.current        = svc.update;
+    changeRoleRef.current    = svc.changeRole;
+    revokeInviteRef.current  = svc.revokeInvite;
+    removeRef.current        = svc.remove;
+    getInviteRef.current     = svc.getInvite;
+    acceptInviteRef.current  = svc.acceptInvite;
+  }, [svc]);
+
+  const [loading, setLoading] = useState(false);
+  const inFlightRef = useRef(false);
+
+  const members = useMemo<Member[]>(() => {
+    return currentSessionId ? map[currentSessionId] ?? [] : [];
+  }, [map, currentSessionId]);
+
+  const refresh = useCallback(
+    async (sessionId?: string) => {
+      const sid = sessionId ?? currentSessionId;
+      if (!sid) return;
+      if (inFlightRef.current) return; // StrictMode guard
+      inFlightRef.current = true;
+      setLoading(true);
+      try {
+        const list = await listBySessionRef.current(sid);
+        setMembers(sid, list);
+      } finally {
+        setLoading(false);
+        inFlightRef.current = false;
+      }
+    },
+    [currentSessionId, setMembers]
+  );
+
+  useEffect(() => {
+    void refresh(); // mount + changement de session
+  }, [refresh]);
+
+  // ---------- Guards “dernier OWNER” ----------
+  function ensureNotDroppingLastOwner(targetMemberId: string, newRole?: Member["role"]) {
+    const owners = members.filter(
+      (m) => m.role === "OWNER" && m.invitationStatus === "ACCEPTED"
+    );
+    const isTargetOwnerAccepted = owners.some((m) => m.id === targetMemberId);
+    const ownersCount = owners.length;
+
+    const removingOwner = isTargetOwnerAccepted && newRole === undefined;            // remove
+    const demotingOwner = isTargetOwnerAccepted && newRole && newRole !== "OWNER";  // change role
+
+    if ((removingOwner || demotingOwner) && ownersCount <= 1) {
+      throw new Error("lastOwner");
+    }
+    if (userIdSelf) {
+      const me = members.find((m) => m.id === targetMemberId);
+      if (me?.userId === userIdSelf && (removingOwner || demotingOwner) && ownersCount <= 1) {
+        throw new Error("selfLastOwner");
+      }
+    }
+  }
+
+  // ---------- Actions haut-niveau pour l’UI ----------
+  async function inviteExisting(userId: string, role: Member["role"]) {
+    if (!currentSessionId) return;
+    const created = await inviteRef.current({ sessionId: currentSessionId, userId, role });
+    await refresh();
+    return created.inviteToken ? makeInviteLink(created.inviteToken) : undefined;
+  }
+
+  async function invitePlaceholder(name: string, role: Member["role"]) {
+    if (!currentSessionId) return;
+    await inviteRef.current({ sessionId: currentSessionId, name, role });
+    await refresh();
+  }
+
+  async function inviteWithLink(role: Member["role"], invitedEmail?: string) {
+    if (!currentSessionId) return;
+    const created = await inviteRef.current({ sessionId: currentSessionId, role, invitedEmail });
+    await refresh();
+    return created.inviteToken ? makeInviteLink(created.inviteToken) : undefined;
+  }
+
+  async function renameMember(memberId: string, name: string) {
+    await updateRef.current(memberId, { name });
+    await refresh();
+  }
+
+  async function changeMemberRole(memberId: string, role: Member["role"]) {
+    ensureNotDroppingLastOwner(memberId, role);
+    await changeRoleRef.current(memberId, role);
+    await refresh();
+  }
+
+  async function revokeMemberInvite(memberId: string) {
+    await revokeInviteRef.current(memberId);
+    await refresh();
+  }
+
+  async function removeMember(memberId: string) {
+    ensureNotDroppingLastOwner(memberId);
+    await removeRef.current(memberId);
+    await refresh();
+  }
+
+  async function readInvite(token: string) {
+    return getInviteRef.current(token);
+  }
+
+  async function acceptInviteToken(token: string) {
+    await acceptInviteRef.current(token);
+    // Ensuite: refresh des sessions côté App + route vers /dashboard/home (à faire dans la page publique)
+  }
+
+  return {
+    currentSessionId,
+    members,
+    loading,
+    refresh,
+    inviteExisting,
+    invitePlaceholder,
+    inviteWithLink,
+    renameMember,
+    changeMemberRole,
+    revokeMemberInvite,
+    removeMember,
+    readInvite,
+    acceptInviteToken,
+  };
+}

--- a/src/i18n/resources/en.json
+++ b/src/i18n/resources/en.json
@@ -151,5 +151,87 @@
       "memberAdded": "Member added to account.",
       "memberRemoved": "Member removed from account."
     }
+  },
+  "members": {
+    "actions": {
+      "invite": "Invite",
+      "revoke": "Revoke",
+      "remove": "Remove",
+      "generateLink": "Generate link"
+    },
+    "roles": {
+      "owner": "Owner",
+      "collaborator": "Collaborator",
+      "viewer": "Viewer"
+    },
+    "status": {
+      "pending": "Pending",
+      "accepted": "Accepted",
+      "declined": "Declined"
+    },
+    "invite": {
+      "title": "Invite a member",
+      "desc": "Add an existing/placeholder member, or generate a share link."
+    },
+    "form": {
+      "tabs": { "existing": "Existing", "placeholder": "Placeholder", "link": "Link" },
+      "userId": "User ID",
+      "userIdRequired": "User ID is required",
+      "name": "Name",
+      "namePh": "e.g. Alex Smith",
+      "nameRequired": "Name is required",
+      "role": "Role",
+      "emailMemo": "Email (memo, optional)",
+      "emailMemoHint": "For reference only (no email will be sent)."
+    },
+    "share": {
+      "title": "Share this link with the invitee:",
+      "copy": "Copy link",
+      "open": "Open",
+      "copied": "Link copied."
+    },
+    "table": {
+      "member": "Member",
+      "role": "Role",
+      "status": "Status",
+      "actions": "Actions"
+    },
+    "empty": {
+      "noSessionTitle": "No active session",
+      "noSessionDesc": "Select or create a session to manage members.",
+      "title": "No members yet",
+      "desc": "Invite your first member to collaborate."
+    },
+    "toasts": {
+      "invited": "Invitation created.",
+      "noToken": "No token returned by the server.",
+      "revoked": "Invitation revoked.",
+      "removed": "Member removed.",
+      "roleChanged": "Role updated.",
+      "errorRole": "Unable to change role.",
+      "errorRemove": "Unable to remove member."
+    },
+    "guards": {
+      "lastOwner": "Blocked: this would remove the last session owner."
+    }
+  },
+  "invite": {
+    "enter": {
+      "title": "Join a session",
+      "desc": "Paste the invite token here (or open the shared link).",
+      "placeholder": "Invite token…",
+      "submit": "Continue"
+    },
+    "accept": {
+      "loading": "Loading invitation…",
+      "invalid": "Invalid or expired invitation.",
+      "title": "Accept invitation",
+      "desc": "You are invited to join this session.",
+      "session": "Session",
+      "email": "Email",
+      "cta": "Accept invitation",
+      "success": "Invitation accepted.",
+      "error": "Failed to accept."
+    }
   }
 }

--- a/src/i18n/resources/fr.json
+++ b/src/i18n/resources/fr.json
@@ -151,5 +151,87 @@
       "memberAdded": "Membre ajouté au compte.",
       "memberRemoved": "Membre retiré du compte."
     }
+  },
+  "members": {
+    "actions": {
+      "invite": "Inviter",
+      "revoke": "Révoquer",
+      "remove": "Retirer",
+      "generateLink": "Générer un lien"
+    },
+    "roles": {
+      "owner": "Propriétaire",
+      "collaborator": "Collaborateur",
+      "viewer": "Lecteur"
+    },
+    "status": {
+      "pending": "En attente",
+      "accepted": "Accepté",
+      "declined": "Refusé"
+    },
+    "invite": {
+      "title": "Inviter un membre",
+      "desc": "Ajoute un membre existant, fictif, ou génère un lien à partager."
+    },
+    "form": {
+      "tabs": { "existing": "Existant", "placeholder": "Fictif", "link": "Lien" },
+      "userId": "ID utilisateur",
+      "userIdRequired": "ID utilisateur requis",
+      "name": "Nom",
+      "namePh": "Ex. Alex Dupont",
+      "nameRequired": "Nom requis",
+      "role": "Rôle",
+      "emailMemo": "E-mail (mémo, optionnel)",
+      "emailMemoHint": "Juste pour mémoire (pas d'envoi d'e-mail)."
+    },
+    "share": {
+      "title": "Partage ce lien avec l’invité :",
+      "copy": "Copier le lien",
+      "open": "Ouvrir",
+      "copied": "Lien copié."
+    },
+    "table": {
+      "member": "Membre",
+      "role": "Rôle",
+      "status": "Statut",
+      "actions": "Actions"
+    },
+    "empty": {
+      "noSessionTitle": "Aucune session active",
+      "noSessionDesc": "Sélectionne ou crée une session pour gérer les membres.",
+      "title": "Aucun membre",
+      "desc": "Invite un premier membre pour collaborer."
+    },
+    "toasts": {
+      "invited": "Invitation créée.",
+      "noToken": "Aucun token renvoyé par le serveur.",
+      "revoked": "Invitation révoquée.",
+      "removed": "Membre retiré.",
+      "roleChanged": "Rôle mis à jour.",
+      "errorRole": "Impossible de changer le rôle.",
+      "errorRemove": "Impossible de retirer le membre."
+    },
+    "guards": {
+      "lastOwner": "Impossible : cela supprimerait le dernier propriétaire de la session."
+    }
+  },
+  "invite": {
+    "enter": {
+      "title": "Rejoindre une session",
+      "desc": "Colle ici le token reçu (ou ouvre directement le lien partagé).",
+      "placeholder": "Token d'invitation…",
+      "submit": "Continuer"
+    },
+    "accept": {
+      "loading": "Chargement de l'invitation…",
+      "invalid": "Invitation invalide ou expirée.",
+      "title": "Accepter l'invitation",
+      "desc": "Tu es invité à rejoindre cette session.",
+      "session": "Session",
+      "email": "E-mail",
+      "cta": "Accepter l'invitation",
+      "success": "Invitation acceptée.",
+      "error": "Échec de l'acceptation."
+    }
   }
 }

--- a/src/lib/service/index.ts
+++ b/src/lib/service/index.ts
@@ -1,3 +1,4 @@
 export * from "./auth.service";
 export * from "./session.service";
 export * from "./bank-account.service";
+export * from "./member.service";

--- a/src/lib/service/member.service.ts
+++ b/src/lib/service/member.service.ts
@@ -1,0 +1,81 @@
+import type { Member } from "@/types";
+import { useApi } from "../api/useApi";
+
+//* DTO attendu par le backend */
+export type InviteMemberDto = {
+    sessionId: string;
+    userId?: string; // si on invite un user existant
+    name?: string; // si on invite un utilisateur fictif
+    invitedEmail?: string; // si on invite un utilisateur par email
+    role: Member["role"];
+};
+
+export type UpdateMemberDto = {
+    name?: string;
+    role?: Member["role"];
+}
+
+//* Response attendu par le frontend */
+export type GetInviteResponse = {
+    id: string;
+    sessionId: string;
+    invitedEmail: string;
+    invitationStatus: "PENDING" | "ACCEPTED" | "DECLINED";
+    invitedAt: string;
+    acceptedAt?: string | null;
+    createdAt: string;
+    updatedAt: string;
+    session: {
+        id: string;
+        name: string;
+    };
+};
+
+
+export function useMembersService() {
+  const { get, post, patch, del } = useApi();
+
+  const listBySession = (sessionId: string) =>
+    get<Member[]>(`/members/session/${sessionId}`);
+
+  const invite = (dto: InviteMemberDto) =>
+    post<Member>("/members", dto); // retourne un Member (PENDING) potentiellement avec inviteToken. :contentReference[oaicite:1]{index=1}
+
+  const update = (memberId: string, data: UpdateMemberDto) =>
+    patch<Member>(`/members/${memberId}`, data); // ex: rename placeholder. :contentReference[oaicite:2]{index=2}
+
+  const changeRole = (memberId: string, role: Member["role"]) =>
+    patch<Member>(`/members/${memberId}/role`, { role }); // OWNER/COLLABORATOR/VIEWER. :contentReference[oaicite:3]{index=3}
+
+  const revokeInvite = (memberId: string) =>
+    del<void>(`/members/invite/${memberId}`); // annule une invitation PENDING. :contentReference[oaicite:4]{index=4}
+
+  const remove = (memberId: string) =>
+    del<void>(`/members/${memberId}`); // retire un membre ACCEPTED. :contentReference[oaicite:5]{index=5}
+
+  const getInvite = (inviteToken: string) =>
+    get<GetInviteResponse>(`/members/invite/${inviteToken}`); // lecture d’une invitation (publique). :contentReference[oaicite:6]{index=6}
+
+  const acceptInvite = (inviteToken: string) =>
+    post<void>(`/members/accept/${inviteToken}`, {}); // acceptation (publique). :contentReference[oaicite:7]{index=7}
+
+  return {
+    listBySession,
+    invite,
+    update,
+    changeRole,
+    revokeInvite,
+    remove,
+    getInvite,
+    acceptInvite,
+  };
+}
+
+export function makeInviteLink(token: string) {
+  try {
+    const origin = window?.location?.origin ?? "";
+    return `${origin}/invite/${token}`;
+  } catch {
+    return `/invite/${token}`;
+  }
+}

--- a/src/pages/invite/AcceptInviteView.tsx
+++ b/src/pages/invite/AcceptInviteView.tsx
@@ -1,0 +1,76 @@
+import { useEffect, useState } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Card, CardHeader, CardTitle, CardContent, CardDescription } from "@/components/ui/card";
+import { useMembers } from "@/hooks/useMembers";
+import { useAuthStore } from "@/stores/authStore"; // si dispo
+
+export default function AcceptInviteView() {
+  const { token } = useParams<{ token: string }>();
+  const { t } = useTranslation();
+  const nav = useNavigate();
+  const { readInvite, acceptInviteToken } = useMembers();
+  const [loading, setLoading] = useState(true);
+  const [info, setInfo] = useState<any>(null);
+
+  useEffect(() => {
+    (async () => {
+      if (!token) return;
+      try {
+        const data = await readInvite(token);
+        setInfo(data);
+      } catch {
+        toast.error(t("invite.accept.invalid"));
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [token, readInvite, t]);
+
+  async function onAccept() {
+    if (!token) return;
+    try {
+      await acceptInviteToken(token);
+      toast.success(t("invite.accept.success"));
+      // si user non connecté → vers /login, sinon dashboard
+      const isAuthed = !!useAuthStore?.getState?.().token;
+      nav(isAuthed ? "/dashboard/home" : "/login", { replace: true });
+    } catch {
+      toast.error(t("invite.accept.error"));
+    }
+  }
+
+  if (loading) {
+    return <div className="p-6 text-sm text-muted-foreground">{t("invite.accept.loading")}</div>;
+  }
+
+  if (!info) {
+    return <div className="p-6 text-sm text-destructive">{t("invite.accept.invalid")}</div>;
+  }
+
+  return (
+    <div className="max-w-lg mx-auto p-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>{t("invite.accept.title")}</CardTitle>
+          <CardDescription>{t("invite.accept.desc")}</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          <div className="text-sm">
+            <span className="text-muted-foreground">{t("invite.accept.session")}:</span>{" "}
+            <span className="font-medium">{info.session?.name ?? info.sessionId}</span>
+          </div>
+          {info.invitedEmail ? (
+            <div className="text-sm">
+              <span className="text-muted-foreground">{t("invite.accept.email")}:</span>{" "}
+              <span>{info.invitedEmail}</span>
+            </div>
+          ) : null}
+          <Button className="mt-2" onClick={onAccept}>{t("invite.accept.cta")}</Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/pages/invite/AcceptInviteView.tsx
+++ b/src/pages/invite/AcceptInviteView.tsx
@@ -49,12 +49,15 @@ export default function AcceptInviteView() {
   if (!info) {
     return <div className="p-6 text-sm text-destructive">{t("invite.accept.invalid")}</div>;
   }
+    if (loading) {
+    return <div className="p-4 sm:p-6 text-sm text-muted-foreground">{t("invite.accept.loading")}</div>;
+  }
 
   return (
-    <div className="max-w-lg mx-auto p-6">
+    <div className="max-w-lg mx-auto p-4 sm:p-6">
       <Card>
         <CardHeader>
-          <CardTitle>{t("invite.accept.title")}</CardTitle>
+          <CardTitle className="text-xl sm:text-2xl">{t("invite.accept.title")}</CardTitle>
           <CardDescription>{t("invite.accept.desc")}</CardDescription>
         </CardHeader>
         <CardContent className="space-y-2">
@@ -68,7 +71,7 @@ export default function AcceptInviteView() {
               <span>{info.invitedEmail}</span>
             </div>
           ) : null}
-          <Button className="mt-2" onClick={onAccept}>{t("invite.accept.cta")}</Button>
+          <Button className="mt-2 w-full sm:w-auto" onClick={onAccept}>{t("invite.accept.cta")}</Button>
         </CardContent>
       </Card>
     </div>

--- a/src/pages/invite/EnterInviteToken.tsx
+++ b/src/pages/invite/EnterInviteToken.tsx
@@ -1,0 +1,29 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useNavigate } from "react-router-dom";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+
+export default function EnterInviteToken() {
+  const { t } = useTranslation();
+  const [token, setToken] = useState("");
+  const nav = useNavigate();
+
+  function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const tok = token.trim();
+    if (!tok) return;
+    nav(`/invite/${tok}`);
+  }
+
+  return (
+    <div className="max-w-md mx-auto p-6 space-y-4">
+      <h1 className="text-2xl font-semibold">{t("invite.enter.title")}</h1>
+      <p className="text-sm text-muted-foreground">{t("invite.enter.desc")}</p>
+      <form onSubmit={onSubmit} className="space-y-2">
+        <Input value={token} onChange={(e) => setToken(e.target.value)} placeholder={t("invite.enter.placeholder") ?? ""} />
+        <Button type="submit">{t("invite.enter.submit")}</Button>
+      </form>
+    </div>
+  );
+}

--- a/src/pages/invite/EnterInviteToken.tsx
+++ b/src/pages/invite/EnterInviteToken.tsx
@@ -17,12 +17,13 @@ export default function EnterInviteToken() {
   }
 
   return (
-    <div className="max-w-md mx-auto p-6 space-y-4">
-      <h1 className="text-2xl font-semibold">{t("invite.enter.title")}</h1>
+    <div className="max-w-md mx-auto p-4 sm:p-6 space-y-4">
+      <h1 className="text-xl sm:text-2xl font-semibold">{t("invite.enter.title")}</h1>
       <p className="text-sm text-muted-foreground">{t("invite.enter.desc")}</p>
       <form onSubmit={onSubmit} className="space-y-2">
-        <Input value={token} onChange={(e) => setToken(e.target.value)} placeholder={t("invite.enter.placeholder") ?? ""} />
-        <Button type="submit">{t("invite.enter.submit")}</Button>
+        <Input className="h-9" value={token} onChange={(e) => setToken(e.target.value)}
+               placeholder={t("invite.enter.placeholder") ?? ""} />
+        <Button type="submit" className="w-full sm:w-auto">{t("invite.enter.submit")}</Button>
       </form>
     </div>
   );

--- a/src/pages/members/index.tsx
+++ b/src/pages/members/index.tsx
@@ -5,12 +5,12 @@ import PageHeader from "@/components/system/PageHeader";
 import EmptyState from "@/components/system/EmptyState";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent } from "@/components/ui/card";
 import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from "@/components/ui/table";
 import { Trash2, Link as LinkIcon } from "lucide-react";
 import { useMembers } from "@/hooks/useMembers";
 import InviteDialog from "@/components/members/InviteDialog";
 import RoleSelect from "@/components/members/RoleSelect";
+import MemberCardItem from "@/components/members/MemberCardItem";
 import type { Member } from "@/types";
 
 export default function MembersPage() {
@@ -35,12 +35,6 @@ export default function MembersPage() {
     return list;
   }, [members]);
 
-  function statusBadge(s?: Member["invitationStatus"]) {
-    if (s === "PENDING") return <Badge variant="secondary">{t("members.status.pending")}</Badge>;
-    if (s === "DECLINED") return <Badge variant="destructive">{t("members.status.declined")}</Badge>;
-    return <Badge>{t("members.status.accepted")}</Badge>;
-  }
-
   async function onRevoke(id: string) {
     await revokeMemberInvite(id);
     toast.success(t("members.toasts.revoked"));
@@ -62,16 +56,8 @@ export default function MembersPage() {
     <section className="p-3 sm:p-4 lg:p-6 space-y-4">
       <PageHeader
         title={t("nav.members")}
-        description={
-          hasSession
-            ? t("pages.common.sessionBound", { id: currentSessionId })
-            : t("pages.common.noSession")
-        }
-        right={
-          <Button onClick={() => setOpenInvite(true)} disabled={!hasSession}>
-            {t("members.actions.invite")}
-          </Button>
-        }
+        description={hasSession ? t("pages.common.sessionBound", { id: currentSessionId }) : t("pages.common.noSession")}
+        right={<Button onClick={() => setOpenInvite(true)} disabled={!hasSession}>{t("members.actions.invite")}</Button>}
       />
 
       {!hasSession ? (
@@ -84,15 +70,23 @@ export default function MembersPage() {
           onAction={() => setOpenInvite(true)}
         />
       ) : (
-        <Card>
-          <CardContent className="p-0">
-            <Table>
+        <>
+          {/* Mobile: cards */}
+          <div className="grid gap-2 md:hidden">
+            {sorted.map((m) => (
+              <MemberCardItem key={m.id} member={m} onRevoke={onRevoke} onRemove={onRemove} />
+            ))}
+          </div>
+
+          {/* Desktop: table */}
+          <div className="hidden md:block overflow-x-auto rounded-lg border">
+            <Table className="min-w-[720px]">
               <TableHeader>
                 <TableRow>
                   <TableHead>{t("members.table.member")}</TableHead>
                   <TableHead>{t("members.table.role")}</TableHead>
                   <TableHead>{t("members.table.status")}</TableHead>
-                  <TableHead className="w-[220px]">{t("members.table.actions")}</TableHead>
+                  <TableHead className="w-[260px]">{t("members.table.actions")}</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
@@ -101,13 +95,20 @@ export default function MembersPage() {
                   const canRevoke = m.invitationStatus === "PENDING";
                   const canRemove = m.invitationStatus === "ACCEPTED";
                   const canCopyLink = !!m.inviteToken && m.invitationStatus === "PENDING";
-
                   return (
                     <TableRow key={m.id}>
                       <TableCell className="font-medium">{display}</TableCell>
-                      <TableCell><RoleSelect member={m} /></TableCell>
-                      <TableCell>{statusBadge(m.invitationStatus)}</TableCell>
-                      <TableCell>
+                      <TableCell className="w-[180px]"><RoleSelect member={m} /></TableCell>
+                      <TableCell className="w-[140px]">
+                        {m.invitationStatus === "PENDING" ? (
+                          <Badge variant="secondary">{t("members.status.pending")}</Badge>
+                        ) : m.invitationStatus === "DECLINED" ? (
+                          <Badge variant="destructive">{t("members.status.declined")}</Badge>
+                        ) : (
+                          <Badge>{t("members.status.accepted")}</Badge>
+                        )}
+                      </TableCell>
+                      <TableCell className="w-[260px]">
                         <div className="flex flex-wrap gap-2">
                           {canCopyLink && (
                             <Button
@@ -140,8 +141,8 @@ export default function MembersPage() {
                 })}
               </TableBody>
             </Table>
-          </CardContent>
-        </Card>
+          </div>
+        </>
       )}
 
       <InviteDialog open={openInvite} onOpenChange={setOpenInvite} />

--- a/src/pages/members/index.tsx
+++ b/src/pages/members/index.tsx
@@ -1,25 +1,150 @@
+import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useSessionStore } from "@/stores/sessionStore";
+import { toast } from "sonner";
 import PageHeader from "@/components/system/PageHeader";
 import EmptyState from "@/components/system/EmptyState";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from "@/components/ui/table";
+import { Trash2, Link as LinkIcon } from "lucide-react";
+import { useMembers } from "@/hooks/useMembers";
+import InviteDialog from "@/components/members/InviteDialog";
+import RoleSelect from "@/components/members/RoleSelect";
+import type { Member } from "@/types";
 
 export default function MembersPage() {
   const { t } = useTranslation();
-  const { currentSessionId } = useSessionStore();
+  const { currentSessionId, members, revokeMemberInvite, removeMember } = useMembers();
+
+  const [openInvite, setOpenInvite] = useState(false);
+
+  const hasSession = !!currentSessionId;
+  const sorted = useMemo<Member[]>(() => {
+    const list = [...members];
+    // ACCEPTED first, then PENDING, then DECLINED; alphabetical by name/email
+    const statusOrder = { ACCEPTED: 0, PENDING: 1, DECLINED: 2 } as const;
+    list.sort((a, b) => {
+      const sa = statusOrder[(a.invitationStatus ?? "ACCEPTED") as keyof typeof statusOrder] ?? 99;
+      const sb = statusOrder[(b.invitationStatus ?? "ACCEPTED") as keyof typeof statusOrder] ?? 99;
+      if (sa !== sb) return sa - sb;
+      const na = (a.name ?? a.invitedEmail ?? a.userId ?? a.id).toLowerCase();
+      const nb = (b.name ?? b.invitedEmail ?? b.userId ?? b.id).toLowerCase();
+      return na.localeCompare(nb);
+    });
+    return list;
+  }, [members]);
+
+  function statusBadge(s?: Member["invitationStatus"]) {
+    if (s === "PENDING") return <Badge variant="secondary">{t("members.status.pending")}</Badge>;
+    if (s === "DECLINED") return <Badge variant="destructive">{t("members.status.declined")}</Badge>;
+    return <Badge>{t("members.status.accepted")}</Badge>;
+  }
+
+  async function onRevoke(id: string) {
+    await revokeMemberInvite(id);
+    toast.success(t("members.toasts.revoked"));
+  }
+  async function onRemove(id: string) {
+    try {
+      await removeMember(id);
+      toast.success(t("members.toasts.removed"));
+    } catch (e: any) {
+      if (e?.message === "lastOwner" || e?.message === "selfLastOwner") {
+        toast.error(t("members.guards.lastOwner"));
+      } else {
+        toast.error(t("members.toasts.errorRemove"));
+      }
+    }
+  }
+
   return (
-    <section className="p-3 sm:p-4 lg:p-6 space-y-3 sm:space-y-4 lg:space-y-6">
+    <section className="p-3 sm:p-4 lg:p-6 space-y-4">
       <PageHeader
         title={t("nav.members")}
         description={
-          currentSessionId
+          hasSession
             ? t("pages.common.sessionBound", { id: currentSessionId })
             : t("pages.common.noSession")
         }
+        right={
+          <Button onClick={() => setOpenInvite(true)} disabled={!hasSession}>
+            {t("members.actions.invite")}
+          </Button>
+        }
       />
-      <EmptyState
-        title={t("pages.common.emptyTitle")}
-        description={t("pages.common.emptyDesc")}
-      />
+
+      {!hasSession ? (
+        <EmptyState title={t("members.empty.noSessionTitle")} description={t("members.empty.noSessionDesc")} />
+      ) : sorted.length === 0 ? (
+        <EmptyState
+          title={t("members.empty.title")}
+          description={t("members.empty.desc")}
+          actionLabel={t("members.actions.invite")}
+          onAction={() => setOpenInvite(true)}
+        />
+      ) : (
+        <Card>
+          <CardContent className="p-0">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>{t("members.table.member")}</TableHead>
+                  <TableHead>{t("members.table.role")}</TableHead>
+                  <TableHead>{t("members.table.status")}</TableHead>
+                  <TableHead className="w-[220px]">{t("members.table.actions")}</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {sorted.map((m) => {
+                  const display = m.name ?? m.invitedEmail ?? m.userId ?? m.id;
+                  const canRevoke = m.invitationStatus === "PENDING";
+                  const canRemove = m.invitationStatus === "ACCEPTED";
+                  const canCopyLink = !!m.inviteToken && m.invitationStatus === "PENDING";
+
+                  return (
+                    <TableRow key={m.id}>
+                      <TableCell className="font-medium">{display}</TableCell>
+                      <TableCell><RoleSelect member={m} /></TableCell>
+                      <TableCell>{statusBadge(m.invitationStatus)}</TableCell>
+                      <TableCell>
+                        <div className="flex flex-wrap gap-2">
+                          {canCopyLink && (
+                            <Button
+                              variant="secondary"
+                              size="sm"
+                              onClick={() => {
+                                const url = `${window.location.origin}/invite/${m.inviteToken}`;
+                                navigator.clipboard.writeText(url).then(() => toast.success(t("members.share.copied")));
+                              }}
+                            >
+                              <LinkIcon className="h-4 w-4 mr-2" />
+                              {t("members.share.copy")}
+                            </Button>
+                          )}
+                          {canRevoke && (
+                            <Button variant="outline" size="sm" onClick={() => onRevoke(m.id)}>
+                              {t("members.actions.revoke")}
+                            </Button>
+                          )}
+                          {canRemove && (
+                            <Button variant="destructive" size="sm" onClick={() => onRemove(m.id)}>
+                              <Trash2 className="h-4 w-4 mr-1" />
+                              {t("members.actions.remove")}
+                            </Button>
+                          )}
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+      )}
+
+      <InviteDialog open={openInvite} onOpenChange={setOpenInvite} />
     </section>
   );
 }

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -12,6 +12,8 @@ import SignupPage from "@/pages/signup";
 import DashboardHome from "@/pages/dashboard/home";
 import SessionSettingsPage from "@/pages/settings/SessionSettingsPage";
 import DashboardNotFound from "@/pages/dashboard/NotFound";
+import EnterInviteToken from "@/pages/invite/EnterInviteToken";
+import AcceptInviteView from "@/pages/invite/AcceptInviteView";
 
 const BanksPage = lazy(() => import("@/pages/banks"));
 const MembersPage = lazy(() => import("@/pages/members"));
@@ -31,6 +33,8 @@ export default function AppRouter() {
             <Route path="/login" element={<LoginPage />} />
             <Route path="/signup" element={<SignupPage />} />
           </Route>
+            <Route path="/invite" element={<EnterInviteToken />} />
+            <Route path="/invite/:token" element={<AcceptInviteView />} />
         </Route>
 
         {/* Zone privée */}


### PR DESCRIPTION
* **Service & Hook**

  * `members.service.ts` : list, invite (userId / name / lien via inviteToken), changeRole, revoke, remove, getInvite, acceptInvite.
  * `useMembers.ts` : session-aware + anti-boucle (refs + in-flight) + helpers (inviteExisting / invitePlaceholder / inviteWithLink / changeRole / revoke / remove / readInvite / acceptInvite).
* **UI /dashboard/members**

  * **InviteDialog** (3 onglets) : Existant, Fictif, **Lien à partager** (copie/ouvrir).
  * **Liste** :

    * **Mobile** → cartes (`MemberCardItem`), actions qui s’empilent proprement.
    * **Desktop** → table avec `overflow-x-auto`, `RoleSelect`, badges statut, actions Révoquer/Retirer, copie du lien.
* **Pages publiques**

  * `/invite` : champ pour **coller un token**.
  * `/invite/:token` : lecture + **Accepter l’invitation** → toast succès → redirection (login si non connecté, sinon dashboard).
* **Responsive**

  * Dialog full-width mobile, inputs/selects 100%, boutons empilés; cartes mobiles et table desktop.
* **Intégration**

  * Utilise `currentSessionId` (J2) et navigation J3 ; toasts/loader via `useApi`.
  * “Refresh infini” : corrigé par stabilisation des deps dans `useMembers`.

# documentation (DoD & suite)

## Definition of Done — J5 Members (MVP)

* [x] **Lister** les membres de la session active (refetch au changement de session).
* [x] **Inviter** : utilisateur existant / fictif / **lien d’invitation** (token partagé).
* [x] **Changer de rôle** (OWNER/COLLABORATOR/VIEWER) avec garde **dernier OWNER**.
* [x] **Révoquer** une invitation **PENDING** / **Retirer** un membre **ACCEPTED**.
* [x] **Pages publiques** `/invite` et `/invite/:token` (lecture + acceptation).
* [x] **Responsive** : mobile-first (cartes), desktop (table), dialog compact.
* [x] Build/typecheck OK, pas de boucles de fetch ni régressions J0–J4.

## QA rapide (reco)

1. Générer un lien depuis **InviteDialog** → copier/ouvrir → `/invite/:token` → **Accepter** → redirection OK.
2. Changer une session dans le **SessionSelector** → la liste se recharge **une fois**.
3. Tenter de rétrograder/retirer le **dernier OWNER** → blocage avec toast explicite.
4. **Révoquer** une invite PENDING puis **Retirer** un membre ACCEPTED (non OWNER) → toasts + refresh.

## Petites améliorations (post-MVP)

* Après **acceptInvite**, déclencher côté app un **refresh `/sessions/my`** et, si pertinent, basculer sur la session rejointe.
* Skeletons/a11y, tests (Vitest/Cypress) → jalon **J12–J13**.
* Filtres/recherche et avatars (hors scope MVP).
