### PR TITLE
feat(j6-incomes): session-aware planned incomes with responsive UI, dialog (RHF+zod), delete confirmation and i18n

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@hookform/resolvers": "^5.2.1",
+        "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-label": "^2.1.7",
         "@radix-ui/react-select": "^2.2.6",
@@ -1148,6 +1149,34 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
       "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
       "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-alert-dialog": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-alert-dialog/-/react-alert-dialog-1.1.15.tgz",
+      "integrity": "sha512-oTVLkEw5GpdRe29BqJ0LSDFWI3qu0vR1M0mUkOQWDIUnY/QIkLpgDMWuKxP94c2NAC2LGcgVhG1ImF3jkZ5wXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dialog": "1.1.15",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@radix-ui/react-arrow": {
       "version": "1.1.7",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.1",
+    "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-select": "^2.2.6",

--- a/src/components/incomes/IncomeCardItem.tsx
+++ b/src/components/incomes/IncomeCardItem.tsx
@@ -1,0 +1,65 @@
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Pencil, Trash2 } from "lucide-react";
+import type { Income, BankAccount, Member } from "@/types";
+import { useTranslation } from "react-i18next";
+
+function toNumberSafely(v: string | number | null | undefined) {
+  if (typeof v === "number") return v;
+  if (typeof v === "string") {
+    const n = Number(v.replace(",", "."));
+    return Number.isFinite(n) ? n : NaN;
+  }
+  return NaN;
+}
+
+export default function IncomeCardItem({
+  income,
+  bank,
+  member,
+  onEdit,
+  onDelete,
+}: {
+  income: Income;
+  bank?: BankAccount;
+  member?: Member;
+  onEdit: (inc: Income) => void;
+  onDelete: (inc: Income) => void;
+}) {
+  const { i18n, t } = useTranslation();
+
+  const n = toNumberSafely((income as any).amount);
+  const amount = new Intl.NumberFormat(i18n.language, {
+    style: "currency",
+    currency: "EUR",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(Number.isFinite(n) ? n : 0);
+
+  return (
+    <Card>
+      <CardContent className="p-3 space-y-2">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <div className="font-medium truncate">{income.label}</div>
+            <div className="text-sm text-muted-foreground">
+              {t("incomes.fields.day")} {income.day} · {bank?.label ?? "—"} ·{" "}
+              {member?.name ?? member?.invitedEmail ?? member?.userId ?? "—"}
+            </div>
+          </div>
+          <div className="text-right font-medium">{amount}</div>
+        </div>
+        <div className="flex flex-col xs:flex-row gap-2">
+          <Button variant="outline" size="sm" className="w-full xs:w-auto" onClick={() => onEdit(income)}>
+            <Pencil className="h-4 w-4 mr-2" />
+            {t("common.edit")}
+          </Button>
+          <Button variant="destructive" size="sm" className="w-full xs:w-auto" onClick={() => onDelete(income)}>
+            <Trash2 className="h-4 w-4 mr-2" />
+            {t("common.delete")}
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/incomes/IncomeFormDialog.tsx
+++ b/src/components/incomes/IncomeFormDialog.tsx
@@ -1,0 +1,208 @@
+import { useEffect } from "react";
+import { useForm, Controller, type SubmitHandler } from "react-hook-form";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
+import {
+  Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select, SelectTrigger, SelectValue, SelectContent, SelectItem,
+} from "@/components/ui/select";
+import type { BankAccount, Member, Income } from "@/types";
+import { useIncomesService } from "@/lib/service/income.service";
+
+// ✅ schéma strict en number (pas de union string|number)
+const schema = z.object({
+  label: z.string().min(1, "Label requis"),
+  amount: z.coerce.number().gt(0, "Montant invalide"),
+  day: z.coerce.number().int().min(1, "Jour invalide").max(31, "Jour invalide"),
+  bankAccountId: z.string().min(1, "Compte requis"),
+  memberId: z.string().min(1, "Membre requis"),
+});
+type FormValues = z.infer<typeof schema>;
+
+type Props = {
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+  mode: "create" | "edit";
+  sessionId: string;
+  income?: Income | null;
+  bankAccounts: BankAccount[];
+  members: Member[];
+  onSuccess?: () => void;
+};
+
+export default function IncomeFormDialog({
+  open, onOpenChange, mode, sessionId, income, bankAccounts, members, onSuccess,
+}: Props) {
+  const { t } = useTranslation();
+  const { create, update } = useIncomesService();
+
+  const {
+    register,
+    control,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+    reset,
+  } = useForm<FormValues>({
+    // ✅ resolver typé explicitement sur FormValues
+    resolver: zodResolver(schema) as any,
+    defaultValues: {
+      label: "",
+      amount: 0,
+      day: 1,
+      bankAccountId: "",
+      memberId: "",
+    },
+  });
+
+  useEffect(() => {
+    if (!open) return;
+    if (mode === "edit" && income) {
+      const amountNum =
+        typeof (income as any).amount === "number"
+          ? (income as any).amount
+          : Number(String((income as any).amount ?? "").replace(",", "."));
+      reset({
+        label: income.label,
+        amount: Number.isFinite(amountNum) ? amountNum : 0,
+        day: (income as any).day,
+        bankAccountId: (income as any).bankAccountId,
+        memberId: (income as any).memberId,
+      });
+    } else {
+      reset({
+        label: "",
+        amount: 0,
+        day: 1,
+        bankAccountId: "",
+        memberId: "",
+      });
+    }
+  }, [open, mode, income, reset]);
+
+  // ✅ handler typé : SubmitHandler<FormValues>
+  const onSubmitForm: SubmitHandler<FormValues> = async (values) => {
+    try {
+      const payload = {
+        sessionId,
+        label: values.label,
+        amount: String(values.amount.toFixed(2)), // API attend string
+        day: values.day,
+        bankAccountId: values.bankAccountId,
+        memberId: values.memberId,
+      };
+      if (mode === "create") {
+        await create(payload);
+        toast.success(t("incomes.toasts.created"));
+      } else if (income) {
+        await update(income.id, payload);
+        toast.success(t("incomes.toasts.updated"));
+      }
+      onOpenChange(false);
+      onSuccess?.();
+    } catch {
+      /* erreurs toast via useApi */
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg max-w-[calc(100vw-1.5rem)]">
+        <DialogHeader>
+          <DialogTitle>
+            {mode === "create" ? t("incomes.form.createTitle") : t("incomes.form.editTitle")}
+          </DialogTitle>
+          <DialogDescription>
+            {mode === "create" ? t("incomes.form.createDesc") : t("incomes.form.editDesc")}
+          </DialogDescription>
+        </DialogHeader>
+
+        {/* ✅ note: handleSubmit reçoit un SubmitHandler<FormValues> */}
+        <form onSubmit={handleSubmit(onSubmitForm)} className="space-y-4">
+          <div className="space-y-2">
+            <label className="text-sm font-medium">{t("incomes.form.label")}</label>
+            <Input className="h-9" {...register("label")} placeholder={t("incomes.form.labelPh") ?? ""} />
+            {errors.label && <p className="text-xs text-destructive">{errors.label.message as any}</p>}
+          </div>
+
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+            <div className="space-y-2">
+              <label className="text-sm font-medium">{t("incomes.form.amount")}</label>
+              <Input className="h-9" inputMode="decimal" {...register("amount")} placeholder="0.00" />
+              {errors.amount && <p className="text-xs text-destructive">{errors.amount.message as any}</p>}
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium">{t("incomes.form.day")}</label>
+              <Input className="h-9" inputMode="numeric" {...register("day")} placeholder="1" />
+              {errors.day && <p className="text-xs text-destructive">{errors.day.message as any}</p>}
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium">{t("incomes.form.bank")}</label>
+              {/* ✅ Controller pour Select */}
+              <Controller
+                control={control}
+                name="bankAccountId"
+                render={({ field }) => (
+                  <Select value={field.value} onValueChange={field.onChange}>
+                    <SelectTrigger className="h-9 w-full">
+                      <SelectValue placeholder={t("incomes.form.bankPh")} />
+                    </SelectTrigger>
+                    <SelectContent className="max-h-[60vh]">
+                      {bankAccounts.map((b) => (
+                        <SelectItem key={b.id} value={b.id}>
+                          {b.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                )}
+              />
+              {errors.bankAccountId && (
+                <p className="text-xs text-destructive">{errors.bankAccountId.message as any}</p>
+              )}
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <label className="text-sm font-medium">{t("incomes.form.member")}</label>
+            <Controller
+              control={control}
+              name="memberId"
+              render={({ field }) => (
+                <Select value={field.value} onValueChange={field.onChange}>
+                  <SelectTrigger className="h-9 w-full">
+                    <SelectValue placeholder={t("incomes.form.memberPh")} />
+                  </SelectTrigger>
+                  <SelectContent className="max-h-[60vh]">
+                    {members.map((m) => (
+                      <SelectItem key={m.id} value={m.id}>
+                        {m.name ?? m.invitedEmail ?? m.userId ?? m.id}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              )}
+            />
+            {errors.memberId && <p className="text-xs text-destructive">{errors.memberId.message as any}</p>}
+          </div>
+
+          <DialogFooter className="flex flex-col sm:flex-row gap-2">
+            <Button type="button" variant="secondary" className="w-full sm:w-auto" onClick={() => onOpenChange(false)}>
+              {t("common.cancel")}
+            </Button>
+            <Button type="submit" className="w-full sm:w-auto" disabled={isSubmitting}>
+              {mode === "create" ? t("common.create") : t("common.save")}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,155 @@
+import * as React from "react"
+import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
+
+import { cn } from "@/lib/utils"
+import { buttonVariants } from "@/components/ui/button"
+
+function AlertDialog({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />
+}
+
+function AlertDialogTrigger({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Trigger>) {
+  return (
+    <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />
+  )
+}
+
+function AlertDialogPortal({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
+  return (
+    <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />
+  )
+}
+
+function AlertDialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Overlay>) {
+  return (
+    <AlertDialogPrimitive.Overlay
+      data-slot="alert-dialog-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Content>) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Content
+        data-slot="alert-dialog-content"
+        className={cn(
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+          className
+        )}
+        {...props}
+      />
+    </AlertDialogPortal>
+  )
+}
+
+function AlertDialogHeader({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-header"
+      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogFooter({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+  return (
+    <AlertDialogPrimitive.Title
+      data-slot="alert-dialog-title"
+      className={cn("text-lg font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+  return (
+    <AlertDialogPrimitive.Description
+      data-slot="alert-dialog-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogAction({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Action>) {
+  return (
+    <AlertDialogPrimitive.Action
+      className={cn(buttonVariants(), className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogCancel({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Cancel>) {
+  return (
+    <AlertDialogPrimitive.Cancel
+      className={cn(buttonVariants({ variant: "outline" }), className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  AlertDialog,
+  AlertDialogPortal,
+  AlertDialogOverlay,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+}

--- a/src/hooks/useIncomes.ts
+++ b/src/hooks/useIncomes.ts
@@ -1,0 +1,48 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useSessionStore } from "@/stores/sessionStore";
+import { useIncomesService } from "@/lib/service/income.service";
+import type { Income } from "@/types";
+
+export function useIncomes() {
+  const { currentSessionId } = useSessionStore();
+  const svc = useIncomesService();
+
+  // refs pour stabiliser les méthodes du service
+  const listBySessionRef = useRef(svc.getBySession);
+  useEffect(() => {
+    listBySessionRef.current = svc.getBySession;
+  }, [svc]);
+
+  const [incomes, setIncomes] = useState<Income[]>([]);
+  const [loading, setLoading] = useState(false);
+  const inFlightRef = useRef(false);
+
+  const refresh = useCallback(
+    async (sessionId?: string) => {
+      const sid = sessionId ?? currentSessionId;
+      if (!sid) return;
+      if (inFlightRef.current) return;
+      inFlightRef.current = true;
+      setLoading(true);
+      try {
+        const list = await listBySessionRef.current(sid);
+        setIncomes(list);
+      } finally {
+        setLoading(false);
+        inFlightRef.current = false;
+      }
+    },
+    [currentSessionId]
+  );
+
+  useEffect(() => {
+    void refresh(); // au mount & quand currentSessionId change
+  }, [refresh]);
+
+  return {
+    currentSessionId,
+    incomes,
+    loading,
+    refresh,
+  };
+}

--- a/src/i18n/resources/en.json
+++ b/src/i18n/resources/en.json
@@ -70,7 +70,8 @@
     "create": "Create",
     "cancel": "Cancel",
     "delete": "Delete",
-    "save": "Save"
+    "save": "Save",
+    "edit": "Edit"
   },
   "sessions": {
     "selector": {
@@ -232,6 +233,47 @@
       "cta": "Accept invitation",
       "success": "Invitation accepted.",
       "error": "Failed to accept."
+    }
+  },
+  "incomes": {
+    "actions": { "new": "New income" },
+    "fields": { "day": "Day" },
+    "form": {
+      "createTitle": "New planned income",
+      "createDesc": "Add a monthly recurring income.",
+      "editTitle": "Edit income",
+      "editDesc": "Update income details.",
+      "label": "Label",
+      "labelPh": "e.g. Salary",
+      "amount": "Amount",
+      "day": "Day of month",
+      "bank": "Bank account",
+      "bankPh": "Select an account…",
+      "member": "Member",
+      "memberPh": "Select a member…"
+    },
+    "table": {
+      "day": "Day",
+      "label": "Label",
+      "amount": "Amount",
+      "bank": "Account",
+      "member": "Member",
+      "actions": "Actions"
+    },
+    "empty": {
+      "noSessionTitle": "No active session",
+      "noSessionDesc": "Select or create a session to manage incomes.",
+      "title": "No planned income",
+      "desc": "Create your first income to get started."
+    },
+    "delete": {
+      "title": "Delete this income?",
+      "desc": "This action is irreversible. \"{{label}}\" will be deleted."
+    },
+    "toasts": {
+      "created": "Income created.",
+      "updated": "Income updated.",
+      "deleted": "Income deleted."
     }
   }
 }

--- a/src/i18n/resources/fr.json
+++ b/src/i18n/resources/fr.json
@@ -70,7 +70,8 @@
     "create": "Créer",
     "cancel": "Annuler",
     "delete": "Supprimer",
-    "save": "Enregistrer"
+    "save": "Enregistrer",
+    "edit": "Éditer"
   },
   "sessions": {
     "selector": {
@@ -232,6 +233,48 @@
       "cta": "Accepter l'invitation",
       "success": "Invitation acceptée.",
       "error": "Échec de l'acceptation."
+    }
+  },
+
+  "incomes": {
+    "actions": { "new": "Nouveau revenu" },
+    "fields": { "day": "Jour" },
+    "form": {
+      "createTitle": "Nouveau revenu planifié",
+      "createDesc": "Ajoute un revenu récurrent au mois.",
+      "editTitle": "Modifier le revenu",
+      "editDesc": "Mets à jour les informations du revenu.",
+      "label": "Intitulé",
+      "labelPh": "Ex. Salaire",
+      "amount": "Montant",
+      "day": "Jour du mois",
+      "bank": "Compte bancaire",
+      "bankPh": "Sélectionner un compte…",
+      "member": "Membre",
+      "memberPh": "Sélectionner un membre…"
+    },
+    "table": {
+      "day": "Jour",
+      "label": "Intitulé",
+      "amount": "Montant",
+      "bank": "Compte",
+      "member": "Membre",
+      "actions": "Actions"
+    },
+    "empty": {
+      "noSessionTitle": "Aucune session active",
+      "noSessionDesc": "Sélectionne ou crée une session pour gérer les revenus.",
+      "title": "Aucun revenu planifié",
+      "desc": "Ajoute ton premier revenu pour démarrer."
+    },
+    "delete": {
+      "title": "Supprimer ce revenu ?",
+      "desc": "Cette action est définitive. \"{{label}}\" sera supprimé."
+    },
+    "toasts": {
+      "created": "Revenu créé.",
+      "updated": "Revenu mis à jour.",
+      "deleted": "Revenu supprimé."
     }
   }
 }

--- a/src/lib/service/income.service.ts
+++ b/src/lib/service/income.service.ts
@@ -1,0 +1,24 @@
+import { useApi } from "@/lib/api/useApi";
+import type { Income, CreateIncomeDto, UpdateIncomeDto } from "@/types";
+
+export function useIncomesService() {
+  const { get, post, patch, del } = useApi();
+
+  /** Liste les revenus planifiés d'une session */
+  const getBySession = (sessionId: string) =>
+    get<Income[]>(`/incomes/session/${sessionId}`);
+
+  /** Crée un revenu planifié */
+  const create = (dto: CreateIncomeDto) =>
+    post<Income>("/incomes", dto);
+
+  /** Met à jour un revenu existant */
+  const update = (incomeId: string, dto: UpdateIncomeDto) =>
+    patch<Income>(`/incomes/${incomeId}`, dto);
+
+  /** Supprime un revenu */
+  const remove = (incomeId: string) =>
+    del<{ success: boolean }>(`/incomes/${incomeId}`);
+
+  return { getBySession, create, update, remove };
+}

--- a/src/lib/service/index.ts
+++ b/src/lib/service/index.ts
@@ -2,3 +2,4 @@ export * from "./auth.service";
 export * from "./session.service";
 export * from "./bank-account.service";
 export * from "./member.service";
+export * from "./income.service";

--- a/src/pages/incomes/index.tsx
+++ b/src/pages/incomes/index.tsx
@@ -1,26 +1,197 @@
+import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useSessionStore } from "@/stores/sessionStore";
 import PageHeader from "@/components/system/PageHeader";
 import EmptyState from "@/components/system/EmptyState";
+import { Button } from "@/components/ui/button";
+import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from "@/components/ui/table";
+import { Badge } from "@/components/ui/badge";
+import { Pencil, Trash2, Plus } from "lucide-react";
+import { AlertDialog, AlertDialogContent, AlertDialogHeader, AlertDialogTitle, AlertDialogDescription, AlertDialogFooter, AlertDialogCancel, AlertDialogAction } from "@/components/ui/alert-dialog";
+import IncomeFormDialog from "@/components/incomes/IncomeFormDialog";
+import IncomeCardItem from "@/components/incomes/IncomeCardItem";
+import { useIncomes } from "@/hooks/useIncomes"; // ← hook Étape 1 (session-aware)
+import { useBanks } from "@/hooks/useBanks";     // pour les selects
+import { useSessionStore } from "@/stores/sessionStore"; // pour les membres courant
+import type { Income } from "@/types";
+import { useIncomesService } from "@/lib/service/income.service";
+import { toast } from "sonner";
+
+function sortIncomes(list: Income[]) {
+  const copy = [...list];
+  copy.sort((a: any, b: any) => {
+    if (a.day !== b.day) return a.day - b.day;
+    return String(a.label).localeCompare(String(b.label));
+  });
+  return copy;
+}
 
 export default function IncomesPage() {
-  const { t } = useTranslation();
-  const { currentSessionId } = useSessionStore();
+  const { t, i18n } = useTranslation();
+
+  const { currentSessionId, incomes, refresh } = useIncomes();
+  const { banks } = useBanks();
+  const { getCurrentMembers } = useSessionStore();
+  const members = getCurrentMembers();
+
+  const [open, setOpen] = useState(false);
+  const [editing, setEditing] = useState<Income | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState<Income | null>(null);
+
+  const { remove } = useIncomesService();
+
+  const hasSession = !!currentSessionId;
+  const sorted = useMemo(() => sortIncomes(incomes as any), [incomes]);
+
+  const banksMap = useMemo(() => new Map(banks.map((b) => [b.id, b])), [banks]);
+  const membersMap = useMemo(() => new Map(members.map((m) => [m.id, m])), [members]);
+
+  function onCreateClick() {
+    setEditing(null);
+    setOpen(true);
+  }
+  function onEditClick(inc: Income) {
+    setEditing(inc);
+    setOpen(true);
+  }
+
+  async function onConfirmDelete() {
+    if (!confirmDelete) return;
+    try {
+      await remove((confirmDelete as any).id);
+      toast.success(t("incomes.toasts.deleted"));
+      setConfirmDelete(null);
+      await refresh();
+    } catch {
+      /* toast via useApi */
+    }
+  }
+
   return (
-    <section className="p-3 sm:p-4 lg:p-6 space-y-3 sm:space-y-4 lg:space-y-6">
+    <section className="p-3 sm:p-4 lg:p-6 space-y-4">
       <PageHeader
         title={t("nav.incomes")}
         description={
-          currentSessionId
+          hasSession
             ? t("pages.common.sessionBound", { id: currentSessionId })
             : t("pages.common.noSession")
         }
+        right={
+          <Button onClick={onCreateClick} disabled={!hasSession}>
+            <Plus className="h-4 w-4 mr-2" />
+            {t("incomes.actions.new")}
+          </Button>
+        }
       />
-      <EmptyState
-        title={t("pages.common.emptyTitle")}
-        description={t("pages.common.emptyDesc")}
-      />
+
+      {!hasSession ? (
+        <EmptyState title={t("incomes.empty.noSessionTitle")} description={t("incomes.empty.noSessionDesc")} />
+      ) : sorted.length === 0 ? (
+        <EmptyState
+          title={t("incomes.empty.title")}
+          description={t("incomes.empty.desc")}
+          actionLabel={t("incomes.actions.new")}
+          onAction={onCreateClick}
+        />
+      ) : (
+        <>
+          {/* Mobile cards */}
+          <div className="grid gap-2 md:hidden">
+            {sorted.map((inc: any) => (
+              <IncomeCardItem
+                key={inc.id}
+                income={inc}
+                bank={banksMap.get(inc.bankAccountId)}
+                member={membersMap.get(inc.memberId)}
+                onEdit={onEditClick}
+                onDelete={(i) => setConfirmDelete(i)}
+              />
+            ))}
+          </div>
+
+          {/* Desktop table */}
+          <div className="hidden md:block overflow-x-auto rounded-lg border">
+            <Table className="min-w-[820px]">
+              <TableHeader>
+                <TableRow>
+                  <TableHead>{t("incomes.table.day")}</TableHead>
+                  <TableHead>{t("incomes.table.label")}</TableHead>
+                  <TableHead>{t("incomes.table.amount")}</TableHead>
+                  <TableHead>{t("incomes.table.bank")}</TableHead>
+                  <TableHead>{t("incomes.table.member")}</TableHead>
+                  <TableHead className="w-[160px]">{t("incomes.table.actions")}</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {sorted.map((inc: any) => {
+                  const bank = banksMap.get(inc.bankAccountId);
+                  const member = membersMap.get(inc.memberId);
+                  const amount = (() => {
+                    const v = typeof inc.amount === "number" ? inc.amount : Number(String(inc.amount ?? "").replace(",", "."));
+                    return Number.isFinite(v)
+                      ? new Intl.NumberFormat(i18n.language, { style: "currency", currency: "EUR" }).format(v)
+                      : "—";
+                  })();
+                  return (
+                    <TableRow key={inc.id}>
+                      <TableCell className="w-[80px]">
+                        <Badge variant="secondary">{inc.day}</Badge>
+                      </TableCell>
+                      <TableCell className="font-medium">{inc.label}</TableCell>
+                      <TableCell>{amount}</TableCell>
+                      <TableCell>{bank?.label ?? "—"}</TableCell>
+                      <TableCell>{member?.name ?? member?.invitedEmail ?? member?.userId ?? "—"}</TableCell>
+                      <TableCell>
+                        <div className="flex flex-wrap gap-2">
+                          <Button variant="outline" size="sm" onClick={() => onEditClick(inc)}>
+                            <Pencil className="h-4 w-4 mr-2" />
+                            {t("common.edit")}
+                          </Button>
+                          <Button variant="destructive" size="sm" onClick={() => setConfirmDelete(inc)}>
+                            <Trash2 className="h-4 w-4 mr-2" />
+                            {t("common.delete")}
+                          </Button>
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          </div>
+        </>
+      )}
+
+      {/* Dialog create/edit */}
+      {hasSession && (
+        <IncomeFormDialog
+          open={open}
+          onOpenChange={setOpen}
+          mode={editing ? "edit" : "create"}
+          sessionId={currentSessionId!}
+          income={editing}
+          bankAccounts={banks}
+          members={members}
+          onSuccess={() => refresh()}
+        />
+      )}
+
+      {/* Confirm delete */}
+      <AlertDialog open={!!confirmDelete} onOpenChange={(v) => !v && setConfirmDelete(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t("incomes.delete.title")}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {t("incomes.delete.desc", { label: confirmDelete?.label ?? "" })}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>{t("common.cancel")}</AlertDialogCancel>
+            <AlertDialogAction className="bg-destructive hover:bg-destructive/90" onClick={onConfirmDelete}>
+              {t("common.delete")}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </section>
   );
 }
-

--- a/src/types/incomes.ts
+++ b/src/types/incomes.ts
@@ -1,0 +1,30 @@
+export type IncomeId = string;
+
+export type Income = {
+  id: IncomeId;
+  sessionId: string;
+  memberId: string;
+  bankAccountId: string;
+  label: string;
+  amount: string; /** Stocké en base en Decimal → on transporte en string pour éviter les erreurs d'arrondi */
+  day: number; /** Jour du mois (1–31) où le revenu est attendu */
+  createdAt?: string;
+  updatedAt?: string;
+};
+
+export type CreateIncomeDto = {
+  sessionId: string;
+  memberId: string;
+  bankAccountId: string;
+  label: string;
+  amount: string; // ex. "2450.00"
+  day: number;    // 1..31
+};
+
+export type UpdateIncomeDto = Partial<{
+  memberId: string;
+  bankAccountId: string;
+  label: string;
+  amount: string;
+  day: number;
+}>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,4 @@
 export * from "./members";
 export * from "./sessions";
 export * from "./banks";
+export * from "./incomes";


### PR DESCRIPTION
### 1) Résumé

Module complet de **revenus planifiés** rattachés à la **session active** :

* **Liste** triée par **jour** puis **intitulé**.
* **Créer / Éditer / Supprimer** via dialog (RHF+zod).
* Rattachement à un **compte bancaire** (J4) et à un **membre** (J2/J5).
* **Responsive** (cartes mobile / table desktop), i18n, toasts, loader via `useApi`.
* Conversion `amount` **number (UI)** → **string (API)**.

### 2) Arborescence & fichiers

```
src/
├─ lib/service/
│  └─ incomes.service.ts                # listBySession/create/update/remove (amount:string côté API)
├─ hooks/
│  └─ useIncomes.ts                     # session-aware + anti-double fetch (refs + in-flight)
├─ components/incomes/
│  ├─ IncomeFormDialog.tsx              # Dialog create/edit (RHF + zod)
│  └─ IncomeCardItem.tsx                # Carte mobile
├─ pages/incomes/
│  └─ index.tsx                         # Page /dashboard/incomes (cards + table)
└─ i18n/resources/
   ├─ fr.json                           # incomes.*
   └─ en.json
```

### 3) Détails d’implémentation

* **Types côté UI** (proposition) :
  `Income { id, sessionId, memberId, bankAccountId, label, amount: number(UI), day: number, createdAt?, updatedAt? }`
* **Service** `useIncomesService()`

  * `listBySession(sessionId)` → `GET /incomes/session/{sessionId}`
  * `create(dto)` → `POST /incomes` *(convertit `amount:number` → `"x.yz"`)*
  * `update(id, dto)` → `PATCH /incomes/{id}` *(idem conversion)*
  * `remove(id)` → `DELETE /incomes/{id}`
* **Hook** `useIncomes()`

  * Se base sur `currentSessionId`, refetch à chaque changement.
  * **Garde StrictMode** (in-flight) + fonctions de service **stabilisées** (refs) pour éviter les boucles.
* **UI** `/dashboard/incomes`

  * **Mobile** : `IncomeCardItem` (actions : éditer/supprimer).
  * **Desktop** : table (jour, libellé, montant, compte, membre, actions).
  * **Dialog** : label, montant, jour (1–31), sélecteur **compte** & **membre**.
  * **Delete** : confirmation.
* **Validation** (zod)

  * `label` requis, `amount` > 0 (tolère saisie “1,23”), `day` ∈ \[1..31], selects requis.
* **i18n**

  * `incomes.*` : labels, validations, toasts, empty states, libellés table.

### 4) Comportements attendus

1. **Création/Édition** : toast succès + refresh liste.
2. **Suppression** : confirm + toast + refresh.
3. **Changement de session** : 1 seul `GET`.
4. **Montant** : affiché avec `Intl.NumberFormat` (EUR) et converti en **string** à l’envoi.

### 5) Endpoints utilisés (MVP)

* `GET /incomes/session/{sessionId}`
* `POST /incomes`
* `PATCH /incomes/{incomeId}`
* `DELETE /incomes/{incomeId}`

### 6) Definition of Done (MVP)

* [x] Service + hook **session-aware** (sans double fetch).
* [x] Page `/dashboard/incomes` : **liste**, **create/edit dialog**, **delete**, i18n.
* [x] Responsive (cartes mobile / table desktop).
* [x] Build/typecheck OK, pas de régression J0–J5.