### PR TITLE
feat(expenses): session-aware planned expenses with responsive UI, dialog, archive toggle, delete confirm and i18n

### DIFF
--- a/src/components/expenses/ExpenseCardItem.tsx
+++ b/src/components/expenses/ExpenseCardItem.tsx
@@ -1,0 +1,60 @@
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Pencil, Trash2, ArchiveRestore, Archive } from "lucide-react";
+import type { Expense, BankAccount, Member } from "@/types";
+import { useTranslation } from "react-i18next";
+
+function nfmt(v: string | number | null | undefined, lang: string) {
+  const n = typeof v === "number" ? v : Number(String(v ?? "").replace(",", "."));
+  return Number.isFinite(n)
+    ? new Intl.NumberFormat(lang, { style: "currency", currency: "EUR" }).format(n)
+    : "—";
+}
+
+export default function ExpenseCardItem({
+  expense, bank, member, onEdit, onDelete, onToggleArchive,
+}: {
+  expense: Expense;
+  bank?: BankAccount;
+  member?: Member;
+  onEdit: (e: Expense) => void;
+  onDelete: (e: Expense) => void;
+  onToggleArchive: (e: Expense) => void;
+}) {
+  const { t, i18n } = useTranslation();
+  const amount = nfmt(expense.amount as any, i18n.language);
+
+  return (
+    <Card>
+      <CardContent className="p-3 space-y-2">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <div className="font-medium truncate">{expense.label}</div>
+            <div className="text-sm text-muted-foreground">
+              {t("expenses.fields.day")} {expense.day} · {bank?.label ?? "—"} ·{" "}
+              {member?.name ?? member?.invitedEmail ?? member?.userId ?? "—"}
+            </div>
+            <div className="mt-1">
+              <Badge variant="secondary">{t(`expenses.categories.${expense.category.toLowerCase()}`)}</Badge>
+              {expense.isArchived && <Badge className="ml-2" variant="outline">{t("expenses.badges.archived")}</Badge>}
+            </div>
+          </div>
+          <div className="text-right font-medium">{amount}</div>
+        </div>
+        <div className="flex flex-col xs:flex-row gap-2">
+          <Button variant="outline" size="sm" className="w-full xs:w-auto" onClick={() => onEdit(expense)}>
+            <Pencil className="h-4 w-4 mr-2" /> {t("common.edit")}
+          </Button>
+          <Button variant="secondary" size="sm" className="w-full xs:w-auto" onClick={() => onToggleArchive(expense)}>
+            {expense.isArchived ? <ArchiveRestore className="h-4 w-4 mr-2" /> : <Archive className="h-4 w-4 mr-2" />}
+            {expense.isArchived ? t("expenses.actions.restore") : t("expenses.actions.archive")}
+          </Button>
+          <Button variant="destructive" size="sm" className="w-full xs:w-auto" onClick={() => onDelete(expense)}>
+            <Trash2 className="h-4 w-4 mr-2" /> {t("common.delete")}
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/expenses/ExpenseFormDialog.tsx
+++ b/src/components/expenses/ExpenseFormDialog.tsx
@@ -1,0 +1,220 @@
+import { useEffect } from "react";
+import { useForm, Controller } from "react-hook-form";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
+import {
+  Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select, SelectTrigger, SelectValue, SelectContent, SelectItem,
+} from "@/components/ui/select";
+import type { BankAccount, Member, Expense } from "@/types";
+import { useExpensesService } from "@/lib/service/expense.service";
+
+const CATEGORY_OPTS: Expense["category"][] = [
+  "HOUSING", "UTILITIES", "HEALTH", "FOOD", "TRANSPORT", "SUBSCRIPTIONS", "OTHER",
+];
+
+const schema = z.object({
+  label: z.string().min(1, "Label requis"),
+  amount: z.coerce.number().gt(0, "Montant invalide"),
+  day: z.coerce.number().int().min(1, "Jour invalide").max(31, "Jour invalide"),
+  bankAccountId: z.string().min(1, "Compte requis"),
+  memberId: z.string().min(1, "Membre requis"),
+  category: z.enum(["HOUSING","UTILITIES","HEALTH","FOOD","TRANSPORT","SUBSCRIPTIONS","OTHER"]),
+});
+
+type FormValues = z.infer<typeof schema>;
+
+type Props = {
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+  mode: "create" | "edit";
+  sessionId: string;
+  expense?: Expense | null;
+  bankAccounts: BankAccount[];
+  members: Member[];
+  onSuccess?: () => void;
+};
+
+export default function ExpenseFormDialog({
+  open, onOpenChange, mode, sessionId, expense, bankAccounts, members, onSuccess,
+}: Props) {
+  const { t } = useTranslation();
+  const { create, update } = useExpensesService();
+
+  const {
+      register,
+      control,
+      handleSubmit,
+      formState: { errors, isSubmitting },
+      reset,
+    } = useForm<FormValues>({
+      // ✅ resolver typé explicitement sur FormValues
+      resolver: zodResolver(schema) as any,
+      defaultValues: {
+        label: "",
+        amount: 0,
+        day: 1,
+        bankAccountId: "",
+        memberId: "",
+      },
+    });
+
+  useEffect(() => {
+    if (!open) return;
+    if (mode === "edit" && expense) {
+      const amountNum =
+        typeof (expense as any).amount === "number"
+          ? (expense as any).amount
+          : Number(String((expense as any).amount ?? "").replace(",", "."));
+      reset({
+        label: expense.label,
+        amount: Number.isFinite(amountNum) ? amountNum : 0,
+        day: (expense as any).day,
+        bankAccountId: (expense as any).bankAccountId,
+        memberId: (expense as any).memberId,
+      });
+    } else {
+      reset({
+        label: "",
+        amount: 0,
+        day: 1,
+        bankAccountId: "",
+        memberId: "",
+      });
+    }
+  }, [open, mode, expense, reset]);
+
+  async function onSubmit(v: FormValues) {
+    try {
+      const payload = {
+        label: v.label,
+        amount: String((v.amount as number).toFixed(2)), // API = string
+        day: v.day,
+        bankAccountId: v.bankAccountId,
+        memberId: v.memberId,
+        category: v.category,
+      };
+      if (mode === "create") {
+        await create({ sessionId, ...payload });
+        toast.success(t("expenses.toasts.created"));
+      } else if (expense) {
+        await update(expense.id, payload);
+        toast.success(t("expenses.toasts.updated"));
+      }
+      onOpenChange(false);
+      onSuccess?.();
+    } catch {
+      /* erreurs toast via useApi */
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg max-w-[calc(100vw-1.5rem)]">
+        <DialogHeader>
+          <DialogTitle>{mode === "create" ? t("expenses.form.createTitle") : t("expenses.form.editTitle")}</DialogTitle>
+          <DialogDescription>{mode === "create" ? t("expenses.form.createDesc") : t("expenses.form.editDesc")}</DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+          <div className="space-y-2">
+            <label className="text-sm font-medium">{t("expenses.form.label")}</label>
+            <Input className="h-9" {...register("label")} placeholder={t("expenses.form.labelPh") ?? ""} />
+            {errors.label && <p className="text-xs text-destructive">{errors.label.message as any}</p>}
+          </div>
+
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+            <div className="space-y-2">
+              <label className="text-sm font-medium">{t("expenses.form.amount")}</label>
+              <Input className="h-9" inputMode="decimal" {...register("amount")} placeholder="0.00" />
+              {errors.amount && <p className="text-xs text-destructive">{errors.amount.message as any}</p>}
+            </div>
+            <div className="space-y-2">
+              <label className="text-sm font-medium">{t("expenses.form.day")}</label>
+              <Input className="h-9" inputMode="numeric" {...register("day")} placeholder="1" />
+              {errors.day && <p className="text-xs text-destructive">{errors.day.message as any}</p>}
+            </div>
+            <div className="space-y-2">
+              <label className="text-sm font-medium">{t("expenses.form.category")}</label>
+              <Controller
+                control={control}
+                name="category"
+                render={({ field }) => (
+                  <Select value={field.value} onValueChange={field.onChange}>
+                    <SelectTrigger className="h-9 w-full">
+                      <SelectValue placeholder={t("expenses.form.categoryPh")} />
+                    </SelectTrigger>
+                    <SelectContent className="max-h-[60vh]">
+                      {CATEGORY_OPTS.map((c) => (
+                        <SelectItem key={c} value={c}>{t(`expenses.categories.${c.toLowerCase()}`)}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                )}
+              />
+            </div>
+          </div>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <div className="space-y-2">
+              <label className="text-sm font-medium">{t("expenses.form.bank")}</label>
+              <Controller
+                control={control}
+                name="bankAccountId"
+                render={({ field }) => (
+                  <Select value={field.value} onValueChange={field.onChange}>
+                    <SelectTrigger className="h-9 w-full">
+                      <SelectValue placeholder={t("expenses.form.bankPh")} />
+                    </SelectTrigger>
+                    <SelectContent className="max-h-[60vh]">
+                      {bankAccounts.map((b) => (
+                        <SelectItem key={b.id} value={b.id}>{b.label}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                )}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium">{t("expenses.form.member")}</label>
+              <Controller
+                control={control}
+                name="memberId"
+                render={({ field }) => (
+                  <Select value={field.value} onValueChange={field.onChange}>
+                    <SelectTrigger className="h-9 w-full">
+                      <SelectValue placeholder={t("expenses.form.memberPh")} />
+                    </SelectTrigger>
+                    <SelectContent className="max-h-[60vh]">
+                      {members.map((m) => (
+                        <SelectItem key={m.id} value={m.id}>
+                          {m.name ?? m.invitedEmail ?? m.userId ?? m.id}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                )}
+              />
+            </div>
+          </div>
+
+          <DialogFooter className="flex flex-col sm:flex-row gap-2">
+            <Button type="button" variant="secondary" className="w-full sm:w-auto" onClick={() => onOpenChange(false)}>
+              {t("common.cancel")}
+            </Button>
+            <Button type="submit" className="w-full sm:w-auto" disabled={isSubmitting}>
+              {mode === "create" ? t("common.create") : t("common.save")}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/hooks/useExpenses.ts
+++ b/src/hooks/useExpenses.ts
@@ -1,0 +1,126 @@
+// src/hooks/useExpenses.ts
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useSessionStore } from "@/stores/sessionStore";
+import { useExpensesService } from "@/lib/service/expense.service";
+import type { Expense } from "@/types";
+
+type CreateOrUpdatePayload = {
+  label: string;
+  amount: number | string; // l'UI peut fournir number
+  day: number;
+  bankAccountId: string;
+  memberId: string;
+  isArchived?: boolean;
+};
+
+export function useExpenses() {
+  const { currentSessionId } = useSessionStore();
+  const svc = useExpensesService();
+
+  // stabilisation des méthodes
+  const listRef = useRef(svc.listBySession);
+  const createRef = useRef(svc.create);
+  const updateRef = useRef(svc.update);
+  const removeRef = useRef(svc.remove);
+  const archiveRef = useRef(svc.archive);
+  const restoreRef = useRef(svc.restore);
+  useEffect(() => {
+    listRef.current = svc.listBySession;
+    createRef.current = svc.create;
+    updateRef.current = svc.update;
+    removeRef.current = svc.remove;
+    archiveRef.current = svc.archive;
+    restoreRef.current = svc.restore;
+  }, [svc]);
+
+  const [loading, setLoading] = useState(false);
+  const [expenses, setExpenses] = useState<Expense[]>([]);
+  const [showArchived, setShowArchived] = useState(false);
+  const inFlight = useRef(false);
+
+  const refresh = useCallback(async (sid?: string) => {
+    const sessionId = sid ?? currentSessionId;
+    if (!sessionId) return;
+    if (inFlight.current) return;
+    inFlight.current = true;
+    setLoading(true);
+    try {
+      const list = await listRef.current(sessionId);
+      setExpenses(list);
+    } finally {
+      setLoading(false);
+      inFlight.current = false;
+    }
+  }, [currentSessionId]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const visible = useMemo(() => {
+    const base = showArchived ? expenses : expenses.filter(e => !e.isArchived);
+    return [...base].sort((a, b) => {
+      if (a.day !== b.day) return a.day - b.day;
+      return a.label.localeCompare(b.label);
+    });
+  }, [expenses, showArchived]);
+
+  // helpers conversion amount -> string "xx.yy"
+  function toApiAmount(v: number | string) {
+    const n = typeof v === "number" ? v : Number(String(v).replace(",", "."));
+    const safe = Number.isFinite(n) ? n : 0;
+    return safe.toFixed(2);
+  }
+
+  async function createExpense(input: CreateOrUpdatePayload) {
+    if (!currentSessionId) return;
+    await createRef.current({
+      sessionId: currentSessionId,
+      label: input.label,
+      amount: toApiAmount(input.amount),
+      day: input.day,
+      bankAccountId: input.bankAccountId,
+      memberId: input.memberId,
+      isArchived: input.isArchived,
+    });
+    await refresh();
+  }
+
+  async function updateExpense(id: string, input: Partial<CreateOrUpdatePayload>) {
+    const dto: any = { ...input };
+    if (input.amount != null) dto.amount = toApiAmount(input.amount);
+    await updateRef.current(id, dto);
+    await refresh();
+  }
+
+  async function deleteExpense(id: string) {
+    await removeRef.current(id);
+    await refresh();
+  }
+
+  async function archiveExpense(id: string) {
+    await archiveRef.current(id);
+    await refresh();
+  }
+
+  async function restoreExpense(id: string) {
+    await restoreRef.current(id);
+    await refresh();
+  }
+
+  return {
+    currentSessionId,
+    loading,
+    expenses,
+    visibleExpenses: visible,
+    showArchived,
+    setShowArchived,
+
+    refresh,
+    createExpense,
+    updateExpense,
+    deleteExpense,
+    archiveExpense,
+    restoreExpense,
+  };
+}

--- a/src/hooks/useExpenses.ts
+++ b/src/hooks/useExpenses.ts
@@ -8,6 +8,7 @@ type CreateOrUpdatePayload = {
   label: string;
   amount: number | string; // l'UI peut fournir number
   day: number;
+  category: Expense["category"];
   bankAccountId: string;
   memberId: string;
   isArchived?: boolean;
@@ -79,6 +80,7 @@ export function useExpenses() {
       label: input.label,
       amount: toApiAmount(input.amount),
       day: input.day,
+      category: input.category,
       bankAccountId: input.bankAccountId,
       memberId: input.memberId,
       isArchived: input.isArchived,

--- a/src/i18n/resources/en.json
+++ b/src/i18n/resources/en.json
@@ -275,5 +275,67 @@
       "updated": "Income updated.",
       "deleted": "Income deleted."
     }
+  },
+  "expenses": {
+    "actions": {
+      "new": "New expense",
+      "archive": "Archive",
+      "restore": "Restore",
+      "showArchived": "Show archived",
+      "hideArchived": "Hide archived"
+    },
+    "badges": { "archived": "Archived" },
+    "fields": { "day": "Day" },
+    "categories": {
+      "housing": "Housing",
+      "utilities": "Utilities",
+      "health": "Health",
+      "food": "Food",
+      "transport": "Transport",
+      "subscriptions": "Subscriptions",
+      "other": "Other"
+    },
+    "form": {
+      "createTitle": "New planned expense",
+      "createDesc": "Add a monthly recurring expense.",
+      "editTitle": "Edit expense",
+      "editDesc": "Update expense details.",
+      "label": "Label",
+      "labelPh": "e.g. Rent",
+      "amount": "Amount",
+      "day": "Day of month",
+      "category": "Category",
+      "categoryPh": "Select a category…",
+      "bank": "Bank account",
+      "bankPh": "Select an account…",
+      "member": "Member",
+      "memberPh": "Select a member…"
+    },
+    "table": {
+      "day": "Day",
+      "label": "Label",
+      "amount": "Amount",
+      "category": "Category",
+      "bank": "Account",
+      "member": "Member",
+      "actions": "Actions"
+    },
+    "empty": {
+      "noSessionTitle": "No active session",
+      "noSessionDesc": "Select or create a session to manage expenses.",
+      "title": "No planned expenses",
+      "desc": "Create your first expense to get started."
+    },
+    "delete": {
+      "title": "Delete this expense?",
+      "desc": "This action is irreversible. \"{{label}}\" will be deleted."
+    },
+    "toasts": {
+      "created": "Expense created.",
+      "updated": "Expense updated.",
+      "deleted": "Expense deleted.",
+      "archived": "Expense archived.",
+      "restored": "Expense restored."
+    }
   }
 }

--- a/src/i18n/resources/fr.json
+++ b/src/i18n/resources/fr.json
@@ -276,5 +276,67 @@
       "updated": "Revenu mis à jour.",
       "deleted": "Revenu supprimé."
     }
+  },
+  "expenses": {
+    "actions": {
+      "new": "Nouvelle dépense",
+      "archive": "Archiver",
+      "restore": "Restaurer",
+      "showArchived": "Afficher archivées",
+      "hideArchived": "Masquer archivées"
+    },
+    "badges": { "archived": "Archivée" },
+    "fields": { "day": "Jour" },
+    "categories": {
+      "housing": "Logement",
+      "utilities": "Charges",
+      "health": "Santé",
+      "food": "Alimentation",
+      "transport": "Transport",
+      "subscriptions": "Abonnements",
+      "other": "Autre"
+    },
+    "form": {
+      "createTitle": "Nouvelle dépense planifiée",
+      "createDesc": "Ajoute une dépense récurrente au mois.",
+      "editTitle": "Modifier la dépense",
+      "editDesc": "Mets à jour les informations de la dépense.",
+      "label": "Intitulé",
+      "labelPh": "Ex. Loyer",
+      "amount": "Montant",
+      "day": "Jour du mois",
+      "category": "Catégorie",
+      "categoryPh": "Sélectionner une catégorie…",
+      "bank": "Compte bancaire",
+      "bankPh": "Sélectionner un compte…",
+      "member": "Membre",
+      "memberPh": "Sélectionner un membre…"
+    },
+    "table": {
+      "day": "Jour",
+      "label": "Intitulé",
+      "amount": "Montant",
+      "category": "Catégorie",
+      "bank": "Compte",
+      "member": "Membre",
+      "actions": "Actions"
+    },
+    "empty": {
+      "noSessionTitle": "Aucune session active",
+      "noSessionDesc": "Sélectionne ou crée une session pour gérer les dépenses.",
+      "title": "Aucune dépense planifiée",
+      "desc": "Ajoute une première dépense pour démarrer."
+    },
+    "delete": {
+      "title": "Supprimer cette dépense ?",
+      "desc": "Cette action est définitive. \"{{label}}\" sera supprimée."
+    },
+    "toasts": {
+      "created": "Dépense créée.",
+      "updated": "Dépense mise à jour.",
+      "deleted": "Dépense supprimée.",
+      "archived": "Dépense archivée.",
+      "restored": "Dépense restaurée."
+    }
   }
 }

--- a/src/lib/service/expense.service.ts
+++ b/src/lib/service/expense.service.ts
@@ -1,0 +1,24 @@
+import { useApi } from "@/lib/api/useApi";
+import type { Expense, CreateExpenseDto, UpdateExpenseDto } from "@/types";
+
+export function useExpensesService() {
+  const { get, post, patch, del } = useApi();
+
+  const listBySession = (sessionId: string) =>
+    get<Expense[]>(`/expenses/session/${sessionId}`);
+
+  const create = (dto: CreateExpenseDto) =>
+    post<Expense>("/expenses", dto);
+
+  const update = (id: string, dto: UpdateExpenseDto) =>
+    patch<Expense>(`/expenses/${id}`, dto);
+
+  const remove = (id: string) =>
+    del<void>(`/expenses/${id}`);
+
+  // helpers d'archive
+  const archive = (id: string) => update(id, { isArchived: true });
+  const restore = (id: string) => update(id, { isArchived: false });
+
+  return { listBySession, create, update, remove, archive, restore };
+}

--- a/src/lib/service/index.ts
+++ b/src/lib/service/index.ts
@@ -3,3 +3,4 @@ export * from "./session.service";
 export * from "./bank-account.service";
 export * from "./member.service";
 export * from "./income.service";
+export * from "./expense.service";

--- a/src/pages/expenses/index.tsx
+++ b/src/pages/expenses/index.tsx
@@ -1,25 +1,202 @@
+import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useSessionStore } from "@/stores/sessionStore";
 import PageHeader from "@/components/system/PageHeader";
 import EmptyState from "@/components/system/EmptyState";
+import { Button } from "@/components/ui/button";
+import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from "@/components/ui/table";
+import { Badge } from "@/components/ui/badge";
+import { Pencil, Trash2, Plus, Archive, ArchiveRestore } from "lucide-react";
+import { AlertDialog, AlertDialogContent, AlertDialogHeader, AlertDialogTitle, AlertDialogDescription, AlertDialogFooter, AlertDialogCancel, AlertDialogAction } from "@/components/ui/alert-dialog";
+import ExpenseFormDialog from "@/components/expenses/ExpenseFormDialog";
+import ExpenseCardItem from "@/components/expenses/ExpenseCardItem";
+import { useExpenses } from "@/hooks/useExpenses";
+import { useBanks } from "@/hooks/useBanks";
+import { useSessionStore } from "@/stores/sessionStore";
+import type { Expense } from "@/types";
+import { useExpensesService } from "@/lib/service/expense.service";
+import { toast } from "sonner";
+
+function nfmt(v: string | number | null | undefined, lang: string) {
+  const n = typeof v === "number" ? v : Number(String(v ?? "").replace(",", "."));
+  return Number.isFinite(n)
+    ? new Intl.NumberFormat(lang, { style: "currency", currency: "EUR" }).format(n)
+    : "—";
+}
 
 export default function ExpensesPage() {
-  const { t } = useTranslation();
-  const { currentSessionId } = useSessionStore();
+  const { t, i18n } = useTranslation();
+
+  const { currentSessionId, visibleExpenses, showArchived, setShowArchived, refresh, archiveExpense, restoreExpense } = useExpenses();
+  const { banks } = useBanks();
+  const { getCurrentMembers } = useSessionStore();
+  const members = getCurrentMembers();
+
+  const [open, setOpen] = useState(false);
+  const [editing, setEditing] = useState<Expense | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState<Expense | null>(null);
+
+  const { remove } = useExpensesService();
+
+  const hasSession = !!currentSessionId;
+  const list = visibleExpenses;
+
+  const banksMap = useMemo(() => new Map(banks.map((b) => [b.id, b])), [banks]);
+  const membersMap = useMemo(() => new Map(members.map((m) => [m.id, m])), [members]);
+
+  function onCreateClick() {
+    setEditing(null);
+    setOpen(true);
+  }
+  function onEditClick(e: Expense) {
+    setEditing(e);
+    setOpen(true);
+  }
+
+  async function onConfirmDelete() {
+    if (!confirmDelete) return;
+    try {
+      await remove(confirmDelete.id);
+      toast.success(t("expenses.toasts.deleted"));
+      setConfirmDelete(null);
+      await refresh();
+    } catch {}
+  }
+
+  async function onToggleArchive(e: Expense) {
+    try {
+      if (e.isArchived) {
+        await restoreExpense(e.id);
+      } else {
+        await archiveExpense(e.id);
+      }
+      toast.success(e.isArchived ? t("expenses.toasts.restored") : t("expenses.toasts.archived"));
+    } catch {}
+  }
+
   return (
-    <section className="p-3 sm:p-4 lg:p-6 space-y-3 sm:space-y-4 lg:space-y-6">
+    <section className="p-3 sm:p-4 lg:p-6 space-y-4">
       <PageHeader
         title={t("nav.expenses")}
-        description={
-          currentSessionId
-            ? t("pages.common.sessionBound", { id: currentSessionId })
-            : t("pages.common.noSession")
+        description={hasSession ? t("pages.common.sessionBound", { id: currentSessionId }) : t("pages.common.noSession")}
+        right={
+          <div className="flex flex-wrap gap-2">
+            <Button variant={showArchived ? "secondary" : "outline"} onClick={() => setShowArchived(!showArchived)} disabled={!hasSession}>
+              {showArchived ? <ArchiveRestore className="h-4 w-4 mr-2" /> : <Archive className="h-4 w-4 mr-2" />}
+              {showArchived ? t("expenses.actions.hideArchived") : t("expenses.actions.showArchived")}
+            </Button>
+            <Button onClick={onCreateClick} disabled={!hasSession}>
+              <Plus className="h-4 w-4 mr-2" /> {t("expenses.actions.new")}
+            </Button>
+          </div>
         }
       />
-      <EmptyState
-        title={t("pages.common.emptyTitle")}
-        description={t("pages.common.emptyDesc")}
-      />
+
+      {!hasSession ? (
+        <EmptyState title={t("expenses.empty.noSessionTitle")} description={t("expenses.empty.noSessionDesc")} />
+      ) : list.length === 0 ? (
+        <EmptyState
+          title={t("expenses.empty.title")}
+          description={t("expenses.empty.desc")}
+          actionLabel={t("expenses.actions.new")}
+          onAction={onCreateClick}
+        />
+      ) : (
+        <>
+          {/* Mobile cards */}
+          <div className="grid gap-2 md:hidden">
+            {list.map((e) => (
+              <ExpenseCardItem
+                key={e.id}
+                expense={e}
+                bank={banksMap.get(e.bankAccountId)}
+                member={membersMap.get(e.memberId)}
+                onEdit={onEditClick}
+                onDelete={(x) => setConfirmDelete(x)}
+                onToggleArchive={onToggleArchive}
+              />
+            ))}
+          </div>
+
+          {/* Desktop table */}
+          <div className="hidden md:block overflow-x-auto rounded-lg border">
+            <Table className="min-w-[920px]">
+              <TableHeader>
+                <TableRow>
+                  <TableHead>{t("expenses.table.day")}</TableHead>
+                  <TableHead>{t("expenses.table.label")}</TableHead>
+                  <TableHead>{t("expenses.table.amount")}</TableHead>
+                  <TableHead>{t("expenses.table.category")}</TableHead>
+                  <TableHead>{t("expenses.table.bank")}</TableHead>
+                  <TableHead>{t("expenses.table.member")}</TableHead>
+                  <TableHead className="w-[240px]">{t("expenses.table.actions")}</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {list.map((e) => {
+                  const bank = banksMap.get(e.bankAccountId);
+                  const member = membersMap.get(e.memberId);
+                  return (
+                    <TableRow key={e.id}>
+                      <TableCell className="w-[80px]"><Badge variant="secondary">{e.day}</Badge></TableCell>
+                      <TableCell className="font-medium">{e.label}{e.isArchived && <Badge className="ml-2" variant="outline">{t("expenses.badges.archived")}</Badge>}</TableCell>
+                      <TableCell>{nfmt(e.amount as any, i18n.language)}</TableCell>
+                      <TableCell><Badge variant="secondary">{t(`expenses.categories.${e.category.toLowerCase()}`)}</Badge></TableCell>
+                      <TableCell>{bank?.label ?? "—"}</TableCell>
+                      <TableCell>{member?.name ?? member?.invitedEmail ?? member?.userId ?? "—"}</TableCell>
+                      <TableCell>
+                        <div className="flex flex-wrap gap-2">
+                          <Button variant="outline" size="sm" onClick={() => onEditClick(e)}>
+                            <Pencil className="h-4 w-4 mr-2" /> {t("common.edit")}
+                          </Button>
+                          <Button variant="secondary" size="sm" onClick={() => onToggleArchive(e)}>
+                            {e.isArchived ? <ArchiveRestore className="h-4 w-4 mr-2" /> : <Archive className="h-4 w-4 mr-2" />}
+                            {e.isArchived ? t("expenses.actions.restore") : t("expenses.actions.archive")}
+                          </Button>
+                          <Button variant="destructive" size="sm" onClick={() => setConfirmDelete(e)}>
+                            <Trash2 className="h-4 w-4 mr-2" /> {t("common.delete")}
+                          </Button>
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          </div>
+        </>
+      )}
+
+      {/* Dialog create/edit */}
+      {hasSession && (
+        <ExpenseFormDialog
+          open={open}
+          onOpenChange={setOpen}
+          mode={editing ? "edit" : "create"}
+          sessionId={currentSessionId!}
+          expense={editing}
+          bankAccounts={banks}
+          members={members}
+          onSuccess={() => refresh()}
+        />
+      )}
+
+      {/* Confirm delete */}
+      <AlertDialog open={!!confirmDelete} onOpenChange={(v) => !v && setConfirmDelete(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t("expenses.delete.title")}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {t("expenses.delete.desc", { label: confirmDelete?.label ?? "" })}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>{t("common.cancel")}</AlertDialogCancel>
+            <AlertDialogAction className="bg-destructive hover:bg-destructive/90" onClick={onConfirmDelete}>
+              {t("common.delete")}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </section>
   );
 }

--- a/src/types/expenses.ts
+++ b/src/types/expenses.ts
@@ -1,0 +1,35 @@
+import type { Member, BankAccount } from "@/types";
+
+export type ExpenseId = string;
+
+export type Expense = {
+  id: ExpenseId;
+  sessionId: string;
+  memberId: string;
+  bankAccountId: string;
+  label: string;
+  amount: string | number;
+  day: number;
+  category: "HOUSING" | "UTILITIES" | "HEALTH" | "FOOD" | "TRANSPORT" | "SUBSCRIPTIONS" | "OTHER";
+  isArchived?: boolean;
+  createdAt?: string;
+  updatedAt?: string;
+  member?: Member;
+  bankAccount?: BankAccount;
+};
+
+export type CreateExpenseDto = {
+  sessionId: string;
+  memberId: string;
+  bankAccountId: string;
+  label: string;
+  amount: string;
+  day: number;
+  isArchived?: boolean;
+};
+
+export type UpdateExpenseDto = Partial<
+  Pick<Expense, "label" | "day" | "memberId" | "bankAccountId" | "isArchived">
+> & {
+  amount?: string;
+};

--- a/src/types/expenses.ts
+++ b/src/types/expenses.ts
@@ -25,11 +25,12 @@ export type CreateExpenseDto = {
   label: string;
   amount: string;
   day: number;
+  category: Expense["category"];
   isArchived?: boolean;
 };
 
 export type UpdateExpenseDto = Partial<
-  Pick<Expense, "label" | "day" | "memberId" | "bankAccountId" | "isArchived">
+  Pick<Expense, "label" | "day" | "memberId" | "bankAccountId" | "isArchived" | "category">
 > & {
   amount?: string;
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,3 +2,4 @@ export * from "./members";
 export * from "./sessions";
 export * from "./banks";
 export * from "./incomes";
+export * from "./expenses";


### PR DESCRIPTION
## 1) Résumé

Gestion des **dépenses récurrentes** de la session :

* **Lister** (tri par **jour**, puis libellé),
* **Créer / Éditer / Supprimer**,
* **Catégoriser** (HOUSING, UTILITIES, HEALTH, FOOD, TRANSPORT, SUBSCRIPTIONS, OTHER),
* **Archiver / Restaurer** + **filtre** “Afficher archivées”,
* **Rattacher** à un **compte bancaire** (J4) et un **membre** (J2/J5),
* **Responsive** (cartes mobile / table desktop), **i18n**, **toasts**, **loader** via `useApi`.

## 2) Arborescence & fichiers

```
src/
├─ types/
│  └─ expenses.ts                       # Expense + DTOs (amount:string API, category)
├─ lib/service/
│  └─ expenses.service.ts               # list/create/update/remove + archive/restore
├─ hooks/
│  └─ useExpenses.ts                    # session-aware, refs + in-flight, filtre archivées
├─ components/expenses/
│  ├─ ExpenseFormDialog.tsx             # Dialog créer/éditer (RHF + zod)
│  └─ ExpenseCardItem.tsx               # Carte mobile (actions Éditer/Archiver/Supprimer)
├─ pages/expenses/
│  └─ index.tsx                         # Page /dashboard/expenses (cards + table)
└─ i18n/resources/
   ├─ fr.json                           # expenses.* (labels, toasts, catégories, empty)
   └─ en.json
```

## 3) Détails d’implémentation

### Types

```ts
export type Expense = {
  id: string;
  sessionId: string;
  memberId: string;
  bankAccountId: string;
  label: string;
  amount: string | number;   // UI number, API string
  day: number;               // 1..31
  category: "HOUSING" | "UTILITIES" | "HEALTH" | "FOOD" | "TRANSPORT" | "SUBSCRIPTIONS" | "OTHER";
  isArchived?: boolean;
  createdAt?: string;
  updatedAt?: string;
};
export type CreateExpenseDto = {
  sessionId: string; memberId: string; bankAccountId: string;
  label: string; amount: string; day: number; category: Expense["category"];
  isArchived?: boolean;
};
export type UpdateExpenseDto = Partial<
  Pick<Expense,"label"|"day"|"memberId"|"bankAccountId"|"isArchived"|"category">
> & { amount?: string; };
```

### Service `useExpensesService()`

* `listBySession(sessionId)` → `GET /expenses/session/{sessionId}`
* `create(dto: CreateExpenseDto)` → `POST /expenses`
* `update(id, dto: UpdateExpenseDto)` → `PATCH /expenses/{id}`
* `remove(id)` → `DELETE /expenses/{id}`
* Helpers : `archive(id)` / `restore(id)` (patch `isArchived`).

### Hook `useExpenses()`

* **Session-aware** : refetch quand `currentSessionId` change.
* **Anti double-fetch** : méthodes de service **stabilisées** via `useRef`, garde **in-flight** (StrictMode).
* **Filtrage/tri** : `visibleExpenses` respecte `showArchived`, tri `(day asc, label asc)`.
* **Helpers** : `createExpense`, `updateExpense`, `deleteExpense`, `archiveExpense`, `restoreExpense`.
* **Conversion montant** : UI number → API string `"xx.yy"`.

### UI `/dashboard/expenses`

* **Header** : bouton **Nouveau**, **toggle Afficher/Masquer archivées**.
* **Mobile** : `ExpenseCardItem` (montant formaté via `Intl.NumberFormat`, badges `category` + `archived`).
* **Desktop** : table (`day`, `label` + badge “Archivée” si besoin, `amount`, `category`, `bank`, `member`, `actions`).
* **Dialog** `ExpenseFormDialog` : `label`, `amount`, `day`, `category`, `bankAccountId`, `memberId`.
* **Supprimer** : `AlertDialog` de confirmation.
* **Responsive** : dialog full-width mobile, table `overflow-x-auto`, boutons qui s’empilent.

### Validation (zod)

* `label` requis,
* `amount` > 0 (tolérance “1,23”),
* `day` ∈ \[1..31],
* `category` requise,
* selects **compte**/**membre** requis.

### i18n

* `expenses.*` : actions (new/archive/restore/show/hide), badges (`archived`), catégories, formulaire, table, empty, delete confirm, toasts.

## 4) Endpoints utilisés

* `GET /expenses/session/{sessionId}`
* `POST /expenses`
* `PATCH /expenses/{expenseId}`
* `DELETE /expenses/{expenseId}`

## 5) Scénarios & comportements attendus

1. **Créer/Éditer** → toast succès + refresh liste.
2. **Archiver/Restaurer** → toast + mise à jour immédiate, respect du filtre.
3. **Supprimer** → confirmation + toast + refresh.
4. **Changement de session** → **un seul** fetch.
5. **Montants** : affichage localisé (EUR), **envoi API en string**.

## 6) Definition of Done (MVP)

* [x] Types/DTO alignés sur `Expense` **avec `category`**.
* [x] Service + hook **stables** (pas de boucle).
* [x] Page `/dashboard/expenses` : liste, **dialog** create/edit, **archive toggle**, **delete confirm**.
* [x] Responsive + i18n + toasts/loader.
* [x] Build/typecheck OK, aucune régression J0–J6.

## 7) QA rapide (recommandée)

* Créer une dépense FOOD jour 5 → visible triée.
* Éditer le **montant** → format OK, envoi string.
* **Archiver** puis activer “Afficher archivées” → l’élément réapparaît avec badge.
* **Restaurer** → redisparaît si “Masquer archivées”.
* Supprimer → confirm + disparition.
* Changer de session → un seul `GET`.

## 8) Lien avec la suite

* **J8 — Budgets (résumés)** : agrège **Incomes (J6)** + **Expenses (J7)** pour le **budget mensuel** (et “fallback auto” si budget manquant).
* **J9 — Transactions** : CRUD + rapprochement et “cleared toggle”.

Si tout est bon pour toi, je prépare le **brief J8**.
