### PR TITLE
feat(budgets): J8 — monthly summary + opening/notes edition + lock/unlock (UI redesign)

### DIFF
--- a/src/components/budgets/CompareTile.tsx
+++ b/src/components/budgets/CompareTile.tsx
@@ -1,0 +1,33 @@
+import { Card, CardContent } from "@/components/ui/card";
+
+export default function CompareTile({
+  title,
+  leftLabel,
+  leftValue,
+  rightLabel,
+  rightValue,
+}: {
+  title: string;
+  leftLabel: string;
+  leftValue: string;
+  rightLabel: string;
+  rightValue: string;
+}) {
+  return (
+    <Card>
+      <CardContent className="p-4 sm:p-5">
+        <div className="text-xs uppercase tracking-wide text-muted-foreground">{title}</div>
+        <div className="grid grid-cols-2 gap-3 mt-2">
+          <div>
+            <div className="text-[11px] uppercase tracking-wide text-muted-foreground">{leftLabel}</div>
+            <div className="text-lg font-semibold">{leftValue}</div>
+          </div>
+          <div className="text-right">
+            <div className="text-[11px] uppercase tracking-wide text-muted-foreground">{rightLabel}</div>
+            <div className="text-lg font-semibold">{rightValue}</div>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/budgets/EditNotesDialog.tsx
+++ b/src/components/budgets/EditNotesDialog.tsx
@@ -1,0 +1,48 @@
+import { useForm } from "react-hook-form";
+import { useTranslation } from "react-i18next";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog";
+import { Textarea } from "@/components/ui/textarea";
+import { Button } from "@/components/ui/button";
+
+type Props = {
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+  initial?: string | null;
+  onSave: (notes: string | null) => Promise<void> | void;
+  disabled?: boolean;
+};
+
+export default function EditNotesDialog({ open, onOpenChange, initial, onSave, disabled }: Props) {
+  const { t } = useTranslation();
+  const { register, handleSubmit } = useForm<{ notes: string }>({
+    defaultValues: { notes: initial ?? "" },
+    values: { notes: initial ?? "" },
+  });
+
+  async function onSubmit(v: { notes: string }) {
+    await onSave(v.notes.trim() === "" ? null : v.notes);
+    onOpenChange(false);
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg max-w-[calc(100vw-1.5rem)]">
+        <DialogHeader>
+          <DialogTitle>{t("budgets.notes.title")}</DialogTitle>
+          <DialogDescription>{t("budgets.notes.desc")}</DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-3">
+          <Textarea rows={5} placeholder={t("budgets.notes.placeholder") ?? ""} {...register("notes")} disabled={disabled} />
+          <DialogFooter className="flex flex-col sm:flex-row gap-2">
+            <Button type="button" variant="secondary" className="w-full sm:w-auto" onClick={() => onOpenChange(false)}>
+              {t("common.cancel")}
+            </Button>
+            <Button type="submit" className="w-full sm:w-auto" disabled={disabled}>
+              {t("common.save")}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/budgets/EditOpeningDialog.tsx
+++ b/src/components/budgets/EditOpeningDialog.tsx
@@ -1,33 +1,59 @@
+import { useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useTranslation } from "react-i18next";
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog";
+import {
+  Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter
+} from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 
 const schema = z.object({
-  amount: z.coerce.number().gt(0, "Montant invalide"),
+  amount: z.coerce
+    .number()
+    .refine((n) => Number.isFinite(n), "Montant invalide"), // supprime n >= 0
 });
+
+type FormValues = z.infer<typeof schema>;
 
 type Props = {
   open: boolean;
   onOpenChange: (v: boolean) => void;
-  initial: string; // "123.45"
+  initial: string;                 // "123.45"
   onSave: (amount: number) => Promise<void> | void;
   disabled?: boolean;
 };
 
-export default function EditOpeningDialog({ open, onOpenChange, initial, onSave, disabled }: Props) {
+function toNumber(initial: string) {
+  const n = Number(String(initial ?? "0").replace(",", "."));
+  return Number.isFinite(n) ? n : 0;
+}
+
+export default function EditOpeningDialog({
+  open, onOpenChange, initial, onSave, disabled,
+}: Props) {
   const { t } = useTranslation();
-  const { register, handleSubmit, formState: { errors, isSubmitting } } = useForm<{ amount: number }>({
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+    reset,
+  } = useForm<FormValues>({
     resolver: zodResolver(schema) as any,
-    defaultValues: { amount: Number(String(initial).replace(",", ".")) },
-    values: { amount: Number(String(initial).replace(",", ".")) },
+    defaultValues: { amount: toNumber(initial) },
   });
 
-  async function onSubmit(v: { amount: number }) {
-    await onSave(v.amount);
+  // IMPORTANT : recharger la valeur au moment de l’ouverture (et si initial change)
+  useEffect(() => {
+    if (open) {
+      reset({ amount: toNumber(initial) });
+    }
+  }, [open, initial, reset]);
+
+  async function onSubmit(v: FormValues) {
+    await onSave(v.amount);        // number ✔
     onOpenChange(false);
   }
 
@@ -38,12 +64,22 @@ export default function EditOpeningDialog({ open, onOpenChange, initial, onSave,
           <DialogTitle>{t("budgets.opening.title")}</DialogTitle>
           <DialogDescription>{t("budgets.opening.desc")}</DialogDescription>
         </DialogHeader>
+
         <form onSubmit={handleSubmit(onSubmit)} className="space-y-3">
           <div className="space-y-1">
             <label className="text-sm font-medium">{t("budgets.opening.label")}</label>
-            <Input className="h-9" inputMode="decimal" placeholder="0.00" {...register("amount")} disabled={disabled} />
-            {errors.amount && <p className="text-xs text-destructive">{errors.amount.message as any}</p>}
+            <Input
+              className="h-9"
+              inputMode="decimal"
+              placeholder="0.00"
+              {...register("amount")}
+              disabled={disabled}
+            />
+            {errors.amount && (
+              <p className="text-xs text-destructive">{String(errors.amount.message)}</p>
+            )}
           </div>
+
           <DialogFooter className="flex flex-col sm:flex-row gap-2">
             <Button type="button" variant="secondary" className="w-full sm:w-auto" onClick={() => onOpenChange(false)}>
               {t("common.cancel")}

--- a/src/components/budgets/EditOpeningDialog.tsx
+++ b/src/components/budgets/EditOpeningDialog.tsx
@@ -1,0 +1,59 @@
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useTranslation } from "react-i18next";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+
+const schema = z.object({
+  amount: z.coerce.number().gt(0, "Montant invalide"),
+});
+
+type Props = {
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+  initial: string; // "123.45"
+  onSave: (amount: number) => Promise<void> | void;
+  disabled?: boolean;
+};
+
+export default function EditOpeningDialog({ open, onOpenChange, initial, onSave, disabled }: Props) {
+  const { t } = useTranslation();
+  const { register, handleSubmit, formState: { errors, isSubmitting } } = useForm<{ amount: number }>({
+    resolver: zodResolver(schema) as any,
+    defaultValues: { amount: Number(String(initial).replace(",", ".")) },
+    values: { amount: Number(String(initial).replace(",", ".")) },
+  });
+
+  async function onSubmit(v: { amount: number }) {
+    await onSave(v.amount);
+    onOpenChange(false);
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md max-w-[calc(100vw-1.5rem)]">
+        <DialogHeader>
+          <DialogTitle>{t("budgets.opening.title")}</DialogTitle>
+          <DialogDescription>{t("budgets.opening.desc")}</DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-3">
+          <div className="space-y-1">
+            <label className="text-sm font-medium">{t("budgets.opening.label")}</label>
+            <Input className="h-9" inputMode="decimal" placeholder="0.00" {...register("amount")} disabled={disabled} />
+            {errors.amount && <p className="text-xs text-destructive">{errors.amount.message as any}</p>}
+          </div>
+          <DialogFooter className="flex flex-col sm:flex-row gap-2">
+            <Button type="button" variant="secondary" className="w-full sm:w-auto" onClick={() => onOpenChange(false)}>
+              {t("common.cancel")}
+            </Button>
+            <Button type="submit" className="w-full sm:w-auto" disabled={isSubmitting || disabled}>
+              {t("common.save")}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/budgets/HeroSummary.tsx
+++ b/src/components/budgets/HeroSummary.tsx
@@ -1,0 +1,43 @@
+import { Card, CardContent } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+
+type Row = { label: string; value: string; tone?: "good" | "bad" | "neutral" };
+
+export default function HeroSummary({
+  title,
+  main,
+  rows,
+  tone = "neutral",
+}: {
+  title: string;
+  main: string;
+  rows: Row[];
+  tone?: "good" | "bad" | "neutral";
+}) {
+  const mainTone =
+    tone === "good" ? "text-emerald-600 dark:text-emerald-400"
+    : tone === "bad" ? "text-rose-600 dark:text-rose-400"
+    : "text-foreground";
+  return (
+    <Card>
+      <CardContent className="p-4 sm:p-5">
+        <div className="text-xs uppercase tracking-wide text-muted-foreground">{title}</div>
+        <div className={cn("text-3xl sm:text-4xl font-semibold mt-1", mainTone)}>{main}</div>
+        <div className="mt-3 grid grid-cols-1 sm:grid-cols-2 gap-2">
+          {rows.map((r, i) => {
+            const toneCls = r.tone === "good" ? "text-emerald-600 dark:text-emerald-400"
+              : r.tone === "bad" ? "text-rose-600 dark:text-rose-400"
+              : "text-foreground";
+            return (
+              <div key={i} className="flex items-center justify-between rounded-md border p-2">
+                <span className="text-xs text-muted-foreground">{r.label}</span>
+                <span className={cn("text-sm font-medium", toneCls)}>{r.value}</span>
+              </div>
+            );
+          })}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+

--- a/src/components/budgets/KpiCard.tsx
+++ b/src/components/budgets/KpiCard.tsx
@@ -1,0 +1,29 @@
+import { Card, CardContent } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+
+type Props = {
+  label: string;
+  value: string;
+  hint?: string;
+  tone?: "neutral" | "good" | "bad";
+};
+
+export default function KpiCard({ label, value, hint, tone = "neutral" }: Props) {
+  const toneCls =
+    tone === "good" ? "text-emerald-600 dark:text-emerald-400"
+    : tone === "bad" ? "text-rose-600 dark:text-rose-400"
+    : "text-foreground";
+  const hintCls =
+    tone === "good" ? "text-emerald-600/70 dark:text-emerald-400/80"
+    : tone === "bad" ? "text-rose-600/70 dark:text-rose-400/80"
+    : "text-muted-foreground";
+  return (
+    <Card>
+      <CardContent className="p-4">
+        <div className="text-xs uppercase tracking-wide text-muted-foreground">{label}</div>
+        <div className={cn("text-xl font-semibold mt-1", toneCls)}>{value}</div>
+        {hint ? <div className={cn("text-xs mt-1", hintCls)}>{hint}</div> : null}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/budgets/ModeTabs.tsx
+++ b/src/components/budgets/ModeTabs.tsx
@@ -1,0 +1,18 @@
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+
+type Props = {
+  value: "planned" | "actual" | "cleared";
+  onChange: (v: "planned" | "actual" | "cleared") => void;
+  disabled?: boolean;
+};
+export default function ModeTabs({ value, onChange, disabled }: Props) {
+  return (
+    <Tabs value={value} onValueChange={(v) => onChange(v as any)}>
+      <TabsList className="grid grid-cols-3 w-full sm:w-auto">
+        <TabsTrigger value="planned" disabled={disabled}>Planned</TabsTrigger>
+        <TabsTrigger value="actual" disabled={disabled}>Actual</TabsTrigger>
+        <TabsTrigger value="cleared" disabled={disabled}>Cleared</TabsTrigger>
+      </TabsList>
+    </Tabs>
+  );
+}

--- a/src/components/budgets/MonthPicker.tsx
+++ b/src/components/budgets/MonthPicker.tsx
@@ -1,0 +1,27 @@
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+type Props = {
+  month: string; // "YYYY-MM"
+  onPrev: () => void;
+  onNext: () => void;
+  onChange: (m: string) => void;
+  disabled?: boolean;
+};
+
+export default function MonthPicker({ month, onPrev, onNext, onChange, disabled }: Props) {
+  return (
+    <div className="flex items-center gap-2">
+      <Button variant="outline" size="icon" onClick={onPrev} disabled={disabled}><ChevronLeft className="h-4 w-4" /></Button>
+      <Input
+        type="month"
+        className="h-9 w-[11.5rem]"
+        value={month}
+        onChange={(e) => onChange(e.target.value)}
+        disabled={disabled}
+      />
+      <Button variant="outline" size="icon" onClick={onNext} disabled={disabled}><ChevronRight className="h-4 w-4" /></Button>
+    </div>
+  );
+}

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,0 +1,18 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        "border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Textarea }

--- a/src/hooks/useBudgetSummary.ts
+++ b/src/hooks/useBudgetSummary.ts
@@ -3,32 +3,33 @@ import { useSessionStore } from "@/stores/sessionStore";
 import { useBudgetsService } from "@/lib/service/budget.service";
 import type { Budget, BudgetSummary, MonthString } from "@/types";
 
-// util interne
-function toMonthString(d = new Date()): MonthString {
+function toMonthString(d: Date = new Date()): MonthString {
   const y = d.getFullYear();
   const m = String(d.getMonth() + 1).padStart(2, "0");
-  return `${y}-${m}` as MonthString;
+  return `${y}-${m}`;
 }
 function toMoneyString(v: number | string) {
   const n = typeof v === "number" ? v : Number(String(v).replace(",", "."));
   const safe = Number.isFinite(n) ? n : 0;
   return safe.toFixed(2);
 }
-const num = (s: string | number | null | undefined) =>
+const toNum = (s: string | number | null | undefined) =>
   Number(String(s ?? "0").replace(",", "."));
 
 export function useBudgetSummary(initialMonth?: MonthString) {
   const { currentSessionId } = useSessionStore();
   const svc = useBudgetsService();
 
-  // stabiliser les méthodes
+  // Stabilisation des méthodes (StrictMode-safe)
   const getSummaryRef = useRef(svc.getSummary);
   const getByMonthRef = useRef(svc.getByMonth);
   const updateRef = useRef(svc.update);
+  const createRef = useRef(svc.create);
   useEffect(() => {
     getSummaryRef.current = svc.getSummary;
     getByMonthRef.current = svc.getByMonth;
     updateRef.current = svc.update;
+    createRef.current = svc.create;
   }, [svc]);
 
   const [month, setMonth] = useState<MonthString>(initialMonth ?? toMonthString());
@@ -36,6 +37,7 @@ export function useBudgetSummary(initialMonth?: MonthString) {
   const [loading, setLoading] = useState(false);
   const inFlight = useRef(false);
 
+  // Charge le résumé avec fallback auto (createIfMissing=true)
   const refresh = useCallback(async () => {
     if (!currentSessionId || !month) return;
     if (inFlight.current) return;
@@ -54,7 +56,7 @@ export function useBudgetSummary(initialMonth?: MonthString) {
     void refresh();
   }, [refresh]);
 
-  // navigation mois
+  // Navigation mois
   const goPrevMonth = useCallback(() => {
     const [y, m] = month.split("-").map(Number);
     const d = new Date(y, m - 2, 1);
@@ -67,95 +69,152 @@ export function useBudgetSummary(initialMonth?: MonthString) {
     setMonth(toMonthString(d));
   }, [month]);
 
-  // assure un budgetId (ton summary utilise désormais "budget")
-  const ensureBudgetId = useCallback(async (): Promise<string | null> => {
-    if (!currentSessionId) return null;
-    if (summary?.budget) return summary.budget; // <-- changement ici
-    try {
-      const b = await getByMonthRef.current(currentSessionId, month);
-      return (b as Budget)?.id ?? null;
-    } catch {
-      return null;
-    }
-  }, [currentSessionId, month, summary?.budget]);
+  // Assure un budget existant, sinon le crée. Met à jour summary.budget avec l'objet Budget.
+  const ensureBudgetIdOrCreate = useCallback(
+    async (opts?: { opening?: number | string; notes?: string | null }): Promise<string | null> => {
+      if (!currentSessionId) return null;
 
-  // actions
+      // 1) Déjà présent dans le summary (objet Budget) ?
+      if (summary?.budget?.id) return summary.budget.id;
+
+      // 2) Essaye de récupérer le budget par mois (si créé ailleurs)
+      try {
+        const b = await getByMonthRef.current(currentSessionId, month);
+        if (b?.id) {
+          setSummary(prev => (prev ? { ...prev, budget: b } : prev));
+          return b.id;
+        }
+      } catch {
+        // 404 attendu si inexistant
+      }
+
+      // 3) Crée un budget si absent
+      try {
+        const opening = toMoneyString(opts?.opening ?? summary?.openingBalance ?? "0");
+        const created = await createRef.current({
+          sessionId: currentSessionId,
+          month,
+          openingBalance: opening,
+          notes: opts?.notes ?? summary?.budget?.notes ?? null,
+        });
+        if (created?.id) {
+          setSummary(prev => (prev ? { ...prev, budget: created } : prev));
+          return created.id;
+        }
+        return null;
+      } catch {
+        return null;
+      }
+    },
+    [currentSessionId, month, summary]
+  );
+
+  // Expose aussi l'objet Budget (sans 404) pour l'UI
+  const getOrCreateBudget = useCallback(async (): Promise<Budget | null> => {
+    // Si le summary embarque déjà le budget complet, retourne-le
+    if (summary?.budget?.id) return summary.budget;
+
+    // Sinon, tente lecture ; si ok, synchronise et renvoie
+    if (currentSessionId) {
+      try {
+        const b = await getByMonthRef.current(currentSessionId, month);
+        if (b?.id) {
+          setSummary(prev => (prev ? { ...prev, budget: b } : prev));
+          return b;
+        }
+      } catch {
+        // ignore
+      }
+    }
+
+    // Sinon, crée et renvoie un objet minimal si l'API n'est pas encore consistante
+    const id = await ensureBudgetIdOrCreate();
+    if (!id || !currentSessionId) return null;
+    return (
+      summary?.budget ?? {
+        id,
+        sessionId: currentSessionId,
+        month,
+        openingBalance: summary?.openingBalance ?? "0.00",
+        notes: null,
+        locked: false,
+      }
+    );
+  }, [summary, currentSessionId, month, ensureBudgetIdOrCreate]);
+
+  // Actions
   const lock = useCallback(async () => {
-    const id = await ensureBudgetId();
+    const id = await ensureBudgetIdOrCreate();
     if (!id) return;
     await updateRef.current(id, { locked: true });
     await refresh();
-  }, [ensureBudgetId, refresh]);
+  }, [ensureBudgetIdOrCreate, refresh]);
 
   const unlock = useCallback(async () => {
-    const id = await ensureBudgetId();
+    const id = await ensureBudgetIdOrCreate();
     if (!id) return;
     await updateRef.current(id, { locked: false });
     await refresh();
-  }, [ensureBudgetId, refresh]);
+  }, [ensureBudgetIdOrCreate, refresh]);
 
-  const updateOpening = useCallback(async (amount: number | string) => {
-    const id = await ensureBudgetId();
-    if (!id) return;
-    await updateRef.current(id, { openingBalance: toMoneyString(amount) });
-    await refresh();
-  }, [ensureBudgetId, refresh]);
+  const updateOpening = useCallback(
+    async (amount: number | string) => {
+      const id = await ensureBudgetIdOrCreate({ opening: amount });
+      if (!id) return;
+      await updateRef.current(id, { openingBalance: toMoneyString(amount) });
+      await refresh();
+    },
+    [ensureBudgetIdOrCreate, refresh]
+  );
 
-  const updateNotes = useCallback(async (notes: string | null) => {
-    const id = await ensureBudgetId();
-    if (!id) return;
-    await updateRef.current(id, { notes: notes ?? null });
-    await refresh();
-  }, [ensureBudgetId, refresh]);
+  const updateNotes = useCallback(
+    async (notes: string | null) => {
+      const id = await ensureBudgetIdOrCreate({ notes });
+      if (!id) return;
+      await updateRef.current(id, { notes: notes ?? null });
+      await refresh();
+    },
+    [ensureBudgetIdOrCreate, refresh]
+  );
 
-  // KPIs dérivés (plats selon ton typage)
+  // KPIs numériques (champs plats du summary)
   const kpis = useMemo(() => {
     if (!summary) return null;
-    const opening = num(summary.openingBalance);
-
-    const plannedIn = num(summary.plannedIncome);
-    const plannedOut = num(summary.plannedExpense);
-    const netPlanned = num(summary.netPlanned);
-    const projectedEndBalance = num(summary.projectedEndBalance);
-
-    const actualIn = num(summary.actualInFlow);
-    const actualOut = num(summary.actualOutFlow);
-    const netActual = num(summary.netActual);
-    const endingBalance = num(summary.endingBalance);
-
-    const clearedIn = num(summary.clearedInFlow);
-    const clearedOut = num(summary.clearedOutFlow);
-    const netCleared = num(summary.netCleared);
-    const clearedEndingBalance = num(summary.clearedEndingBalance);
-
     return {
-      opening,
-      plannedIn,
-      plannedOut,
-      netPlanned,
-      projectedEndBalance,
-      actualIn,
-      actualOut,
-      netActual,
-      endingBalance,
-      clearedIn,
-      clearedOut,
-      netCleared,
-      clearedEndingBalance,
+      opening: toNum(summary.openingBalance),
+      plannedIn: toNum(summary.plannedIncome),
+      plannedOut: toNum(summary.plannedExpense),
+      netPlanned: toNum(summary.netPlanned),
+      projectedEndBalance: toNum(summary.projectedEndBalance),
+      actualIn: toNum(summary.actualInFlow),
+      actualOut: toNum(summary.actualOutFlow),
+      netActual: toNum(summary.netActual),
+      endingBalance: toNum(summary.endingBalance),
+      clearedIn: toNum(summary.clearedInFlow),
+      clearedOut: toNum(summary.clearedOutFlow),
+      netCleared: toNum(summary.netCleared),
+      clearedEndingBalance: toNum(summary.clearedEndingBalance),
     };
   }, [summary]);
 
   return {
     // état
     month,
-    setMonth, goPrevMonth, goNextMonth,
+    setMonth,
+    goPrevMonth,
+    goNextMonth,
     summary,
     loading,
     kpis,
 
     // actions
     refresh,
-    lock, unlock,
-    updateOpening, updateNotes,
+    lock,
+    unlock,
+    updateOpening,
+    updateNotes,
+
+    // helper pour l'UI
+    getOrCreateBudget,
   };
 }

--- a/src/hooks/useBudgetSummary.ts
+++ b/src/hooks/useBudgetSummary.ts
@@ -1,0 +1,161 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useSessionStore } from "@/stores/sessionStore";
+import { useBudgetsService } from "@/lib/service/budget.service";
+import type { Budget, BudgetSummary, MonthString } from "@/types";
+
+// util interne
+function toMonthString(d = new Date()): MonthString {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  return `${y}-${m}` as MonthString;
+}
+function toMoneyString(v: number | string) {
+  const n = typeof v === "number" ? v : Number(String(v).replace(",", "."));
+  const safe = Number.isFinite(n) ? n : 0;
+  return safe.toFixed(2);
+}
+const num = (s: string | number | null | undefined) =>
+  Number(String(s ?? "0").replace(",", "."));
+
+export function useBudgetSummary(initialMonth?: MonthString) {
+  const { currentSessionId } = useSessionStore();
+  const svc = useBudgetsService();
+
+  // stabiliser les méthodes
+  const getSummaryRef = useRef(svc.getSummary);
+  const getByMonthRef = useRef(svc.getByMonth);
+  const updateRef = useRef(svc.update);
+  useEffect(() => {
+    getSummaryRef.current = svc.getSummary;
+    getByMonthRef.current = svc.getByMonth;
+    updateRef.current = svc.update;
+  }, [svc]);
+
+  const [month, setMonth] = useState<MonthString>(initialMonth ?? toMonthString());
+  const [summary, setSummary] = useState<BudgetSummary | null>(null);
+  const [loading, setLoading] = useState(false);
+  const inFlight = useRef(false);
+
+  const refresh = useCallback(async () => {
+    if (!currentSessionId || !month) return;
+    if (inFlight.current) return;
+    inFlight.current = true;
+    setLoading(true);
+    try {
+      const s = await getSummaryRef.current(currentSessionId, month, { createIfMissing: true });
+      setSummary(s);
+    } finally {
+      setLoading(false);
+      inFlight.current = false;
+    }
+  }, [currentSessionId, month]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  // navigation mois
+  const goPrevMonth = useCallback(() => {
+    const [y, m] = month.split("-").map(Number);
+    const d = new Date(y, m - 2, 1);
+    setMonth(toMonthString(d));
+  }, [month]);
+
+  const goNextMonth = useCallback(() => {
+    const [y, m] = month.split("-").map(Number);
+    const d = new Date(y, m, 1);
+    setMonth(toMonthString(d));
+  }, [month]);
+
+  // assure un budgetId (ton summary utilise désormais "budget")
+  const ensureBudgetId = useCallback(async (): Promise<string | null> => {
+    if (!currentSessionId) return null;
+    if (summary?.budget) return summary.budget; // <-- changement ici
+    try {
+      const b = await getByMonthRef.current(currentSessionId, month);
+      return (b as Budget)?.id ?? null;
+    } catch {
+      return null;
+    }
+  }, [currentSessionId, month, summary?.budget]);
+
+  // actions
+  const lock = useCallback(async () => {
+    const id = await ensureBudgetId();
+    if (!id) return;
+    await updateRef.current(id, { locked: true });
+    await refresh();
+  }, [ensureBudgetId, refresh]);
+
+  const unlock = useCallback(async () => {
+    const id = await ensureBudgetId();
+    if (!id) return;
+    await updateRef.current(id, { locked: false });
+    await refresh();
+  }, [ensureBudgetId, refresh]);
+
+  const updateOpening = useCallback(async (amount: number | string) => {
+    const id = await ensureBudgetId();
+    if (!id) return;
+    await updateRef.current(id, { openingBalance: toMoneyString(amount) });
+    await refresh();
+  }, [ensureBudgetId, refresh]);
+
+  const updateNotes = useCallback(async (notes: string | null) => {
+    const id = await ensureBudgetId();
+    if (!id) return;
+    await updateRef.current(id, { notes: notes ?? null });
+    await refresh();
+  }, [ensureBudgetId, refresh]);
+
+  // KPIs dérivés (plats selon ton typage)
+  const kpis = useMemo(() => {
+    if (!summary) return null;
+    const opening = num(summary.openingBalance);
+
+    const plannedIn = num(summary.plannedIncome);
+    const plannedOut = num(summary.plannedExpense);
+    const netPlanned = num(summary.netPlanned);
+    const projectedEndBalance = num(summary.projectedEndBalance);
+
+    const actualIn = num(summary.actualInFlow);
+    const actualOut = num(summary.actualOutFlow);
+    const netActual = num(summary.netActual);
+    const endingBalance = num(summary.endingBalance);
+
+    const clearedIn = num(summary.clearedInFlow);
+    const clearedOut = num(summary.clearedOutFlow);
+    const netCleared = num(summary.netCleared);
+    const clearedEndingBalance = num(summary.clearedEndingBalance);
+
+    return {
+      opening,
+      plannedIn,
+      plannedOut,
+      netPlanned,
+      projectedEndBalance,
+      actualIn,
+      actualOut,
+      netActual,
+      endingBalance,
+      clearedIn,
+      clearedOut,
+      netCleared,
+      clearedEndingBalance,
+    };
+  }, [summary]);
+
+  return {
+    // état
+    month,
+    setMonth, goPrevMonth, goNextMonth,
+    summary,
+    loading,
+    kpis,
+
+    // actions
+    refresh,
+    lock, unlock,
+    updateOpening, updateNotes,
+  };
+}

--- a/src/i18n/resources/en.json
+++ b/src/i18n/resources/en.json
@@ -337,5 +337,52 @@
       "archived": "Expense archived.",
       "restored": "Expense restored."
     }
+  },
+  "budgets": {
+    "actions": {
+      "lock": "Lock",
+      "unlock": "Unlock",
+      "editOpening": "Opening balance",
+      "editNotes": "Notes"
+    },
+    "opening": {
+      "title": "Edit opening balance",
+      "desc": "Enter the opening balance for this month.",
+      "label": "Balance"
+    },
+    "notes": {
+      "title": "Edit notes",
+      "titleShort": "Notes",
+      "desc": "Add helpful context for this month.",
+      "placeholder": "Month notes…",
+      "empty": "No notes for this month."
+    },
+    "kpi": {
+      "opening": "Opening",
+      "plannedIn": "Planned (In)",
+      "plannedOut": "Planned (Out)",
+      "netPlanned": "Net planned",
+      "projectedEnd": "Projected closing",
+      "actualIn": "Actual (In)",
+      "actualOut": "Actual (Out)",
+      "netActual": "Net actual",
+      "ending": "Closing",
+      "clearedIn": "Cleared (In)",
+      "clearedOut": "Cleared (Out)",
+      "netCleared": "Net cleared"
+    },
+    "hints": {
+      "netPlanned": "Planned income − planned expense"
+    },
+    "empty": {
+      "noSessionTitle": "No active session",
+      "noSessionDesc": "Select or create a session to view budgets.",
+      "title": "No budget data",
+      "desc": "The summary will be created automatically if needed."
+    },
+    "toasts": {
+      "locked": "Budget locked.",
+      "unlocked": "Budget unlocked."
+    }
   }
 }

--- a/src/i18n/resources/en.json
+++ b/src/i18n/resources/en.json
@@ -383,6 +383,22 @@
     "toasts": {
       "locked": "Budget locked.",
       "unlocked": "Budget unlocked."
+    },
+     "hero": {
+      "projected": "Projected closing (Planned)",
+      "ending": "Closing (Actual)",
+      "clearedEnding": "Cleared closing"
+    },
+    "rows": {
+      "opening": "Opening",
+      "in": "Inflow",
+      "out": "Outflow",
+      "net": "Net",
+      "base": "Base (Closing)"
+    },
+    "compare": {
+      "inflow": "Inflow comparison",
+      "outflow": "Outflow comparison"
     }
   }
 }

--- a/src/i18n/resources/fr.json
+++ b/src/i18n/resources/fr.json
@@ -384,6 +384,22 @@
     "toasts": {
       "locked": "Budget verrouillé.",
       "unlocked": "Budget déverrouillé."
+    },
+    "hero": {
+      "projected": "Clôture estimée (Planned)",
+      "ending": "Clôture (Actual)",
+      "clearedEnding": "Clôture pointée (Cleared)"
+    },
+    "rows": {
+      "opening": "Ouverture",
+      "in": "Entrées",
+      "out": "Sorties",
+      "net": "Net",
+      "base": "Base (Clôture)"
+    },
+    "compare": {
+      "inflow": "Comparatif Entrées",
+      "outflow": "Comparatif Sorties"
     }
   }
 }

--- a/src/i18n/resources/fr.json
+++ b/src/i18n/resources/fr.json
@@ -32,7 +32,7 @@
     "settings": "Paramètres",
     "signup": "Inscrivez-vous",
     "login": "Connectez-vous",
-     "home": "Accueil",
+    "home": "Accueil",
     "transactions": "Transactions",
     "sessions": "Sessions"
   },
@@ -337,6 +337,53 @@
       "deleted": "Dépense supprimée.",
       "archived": "Dépense archivée.",
       "restored": "Dépense restaurée."
+    }
+  },
+  "budgets": {
+    "actions": {
+      "lock": "Verrouiller",
+      "unlock": "Déverrouiller",
+      "editOpening": "Solde d’ouverture",
+      "editNotes": "Notes"
+    },
+    "opening": {
+      "title": "Modifier le solde d’ouverture",
+      "desc": "Saisis le solde d’ouverture pour ce mois.",
+      "label": "Solde"
+    },
+    "notes": {
+      "title": "Modifier les notes",
+      "titleShort": "Notes",
+      "desc": "Ajoute des informations utiles pour ce budget.",
+      "placeholder": "Notes du mois…",
+      "empty": "Aucune note pour ce mois."
+    },
+    "kpi": {
+      "opening": "Ouverture",
+      "plannedIn": "Planifié (Entrées)",
+      "plannedOut": "Planifié (Sorties)",
+      "netPlanned": "Net planifié",
+      "projectedEnd": "Clôture estimée",
+      "actualIn": "Réel (Entrées)",
+      "actualOut": "Réel (Sorties)",
+      "netActual": "Net réel",
+      "ending": "Clôture",
+      "clearedIn": "Pointé (Entrées)",
+      "clearedOut": "Pointé (Sorties)",
+      "netCleared": "Net pointé"
+    },
+    "hints": {
+      "netPlanned": "Entrées planifiées − sorties planifiées"
+    },
+    "empty": {
+      "noSessionTitle": "Aucune session active",
+      "noSessionDesc": "Sélectionne ou crée une session pour voir le budget.",
+      "title": "Aucune donnée budgétaire",
+      "desc": "Le résumé sera généré automatiquement au besoin."
+    },
+    "toasts": {
+      "locked": "Budget verrouillé.",
+      "unlocked": "Budget déverrouillé."
     }
   }
 }

--- a/src/lib/service/budget.service.ts
+++ b/src/lib/service/budget.service.ts
@@ -1,0 +1,52 @@
+// src/lib/service/budgets.service.ts
+import { useApi } from "@/lib/api/useApi";
+import type {
+  Budget,
+  BudgetSummary,
+  CreateBudgetDto,
+  MonthString,
+  UpdateBudgetDto,
+} from "@/types";
+
+export function useBudgetsService() {
+  const { get, post, patch, del } = useApi();
+
+  // Liste des budgets d'une session
+  const listBySession = (sessionId: string) =>
+    get<Budget[]>(`/budgets/session/${sessionId}`);
+
+  // Lire un budget d'un mois précis (retourne Budget ou 404 si absent)
+  const getByMonth = (sessionId: string, month: MonthString) =>
+    get<Budget>(`/budgets/session/${sessionId}?month=${month}`);
+
+  // Créer un budget
+  const create = (dto: CreateBudgetDto) =>
+    post<Budget>("/budgets", dto);
+
+  // Modifier (openingBalance, notes, locked)
+  const update = (budgetId: string, dto: UpdateBudgetDto) =>
+    patch<Budget>(`/budgets/${budgetId}`, dto);
+
+  // Supprimer (facultatif pour QA)
+  const remove = (budgetId: string) =>
+    del<void>(`/budgets/${budgetId}`);
+
+  // Résumé du mois (source unique pour la page) + fallback auto
+  const getSummary = (
+    sessionId: string,
+    month: MonthString,
+    opts?: { createIfMissing?: boolean }
+  ) => {
+    const q = opts?.createIfMissing ? "?createIfMissing=true" : "";
+    return get<BudgetSummary>(`/budgets/session/${sessionId}/${month}/summary${q}`);
+  };
+
+  return {
+    listBySession,
+    getByMonth,
+    create,
+    update,
+    remove,
+    getSummary,
+  };
+}

--- a/src/lib/service/budget.service.ts
+++ b/src/lib/service/budget.service.ts
@@ -8,30 +8,47 @@ import type {
   UpdateBudgetDto,
 } from "@/types";
 
+function normId(input: string | { id?: string } | null | undefined): string {
+  if (!input) return "";
+  if (typeof input === "string") return input;
+  if (typeof input.id === "string") return input.id;
+  return ""; // on retourne "" => le client lèvera une erreur propre
+}
+
 export function useBudgetsService() {
   const { get, post, patch, del } = useApi();
 
-  // Liste des budgets d'une session
   const listBySession = (sessionId: string) =>
     get<Budget[]>(`/budgets/session/${sessionId}`);
 
-  // Lire un budget d'un mois précis (retourne Budget ou 404 si absent)
   const getByMonth = (sessionId: string, month: MonthString) =>
     get<Budget>(`/budgets/session/${sessionId}?month=${month}`);
 
-  // Créer un budget
   const create = (dto: CreateBudgetDto) =>
     post<Budget>("/budgets", dto);
 
-  // Modifier (openingBalance, notes, locked)
-  const update = (budgetId: string, dto: UpdateBudgetDto) =>
-    patch<Budget>(`/budgets/${budgetId}`, dto);
+  // ✅ tolère string OU objet {id}, évite /budgets/[object Object]
+  const update = (
+    budget: string | { id?: string },
+    dto: UpdateBudgetDto
+  ) => {
+    const id = normId(budget);
+    if (!id) {
+      // Déclenche une erreur claire (toaster géré par useApi)
+      throw new Error("Invalid budget id passed to update()");
+    }
+    return patch<Budget>(`/budgets/${id}`, dto);
+  };
 
-  // Supprimer (facultatif pour QA)
-  const remove = (budgetId: string) =>
-    del<void>(`/budgets/${budgetId}`);
+  // ✅ idem
+  const remove = (budget: string | { id?: string }) => {
+    const id = normId(budget);
+    if (!id) {
+      throw new Error("Invalid budget id passed to remove()");
+    }
+    return del<void>(`/budgets/${id}`);
+  };
 
-  // Résumé du mois (source unique pour la page) + fallback auto
   const getSummary = (
     sessionId: string,
     month: MonthString,

--- a/src/lib/service/index.ts
+++ b/src/lib/service/index.ts
@@ -4,3 +4,4 @@ export * from "./bank-account.service";
 export * from "./member.service";
 export * from "./income.service";
 export * from "./expense.service";
+export * from "./budget.service";

--- a/src/pages/budgets/index.tsx
+++ b/src/pages/budgets/index.tsx
@@ -5,7 +5,6 @@ import EmptyState from "@/components/system/EmptyState";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import MonthPicker from "@/components/budgets/MonthPicker";
-import KpiCard from "@/components/budgets/KpiCard";
 import EditOpeningDialog from "@/components/budgets/EditOpeningDialog";
 import EditNotesDialog from "@/components/budgets/EditNotesDialog";
 import { Lock, Unlock, Pencil } from "lucide-react";
@@ -14,12 +13,16 @@ import { useSessionStore } from "@/stores/sessionStore";
 import { useBudgetsService } from "@/lib/service/budget.service";
 import type { Budget } from "@/types";
 import { toast } from "sonner";
+import CompareTile from "@/components/budgets/CompareTile";
+import HeroSummary from "@/components/budgets/HeroSummary";
+import ModeTabs from "@/components/budgets/ModeTabs";
 
 function fmtEUR(v: number, lang: string) {
   return new Intl.NumberFormat(lang, { style: "currency", currency: "EUR" }).format(v);
 }
 
 export default function BudgetsPage() {
+  const [mode, setMode] = useState<"planned" | "actual" | "cleared">("planned");
   const { t, i18n } = useTranslation();
   const { currentSessionId } = useSessionStore();
   const hasSession = !!currentSessionId;
@@ -57,23 +60,29 @@ export default function BudgetsPage() {
   }
 
   return (
-    <section className="p-3 sm:p-4 lg:p-6 space-y-4">
-      <PageHeader
-        title={t("nav.budgets")}
-        description={
-          hasSession
-            ? t("pages.common.sessionBound", { id: currentSessionId })
-            : t("pages.common.noSession")
-        }
-        right={
-          <div className="flex flex-wrap gap-2">
-            <MonthPicker
-              month={month}
-              onPrev={goPrevMonth}
-              onNext={goNextMonth}
-              onChange={(m) => setMonth(m)}
-              disabled={!hasSession}
-            />
+  <section className="p-3 sm:p-4 lg:p-6 space-y-4">
+    <PageHeader
+      title={t("nav.budgets")}
+      description={
+        hasSession
+          ? t("pages.common.sessionBound", { id: currentSessionId })
+          : t("pages.common.noSession")
+      }
+      right={
+        <div className="flex flex-col sm:flex-row gap-2 sm:items-center">
+          <MonthPicker
+            month={month}
+            onPrev={goPrevMonth}
+            onNext={goNextMonth}
+            onChange={(m) => setMonth(m)}
+            disabled={!hasSession}
+          />
+          <ModeTabs
+            value={(mode as any) ?? "planned"}
+            onChange={(m) => setMode(m)}
+            disabled={!hasSession}
+          />
+          <div className="flex gap-2">
             <Button variant={locked ? "secondary" : "outline"} onClick={onToggleLock} disabled={!hasSession}>
               {locked ? <Unlock className="h-4 w-4 mr-2" /> : <Lock className="h-4 w-4 mr-2" />}
               {locked ? t("budgets.actions.unlock") : t("budgets.actions.lock")}
@@ -87,70 +96,122 @@ export default function BudgetsPage() {
               {t("budgets.actions.editNotes")}
             </Button>
           </div>
-        }
-      />
-
-      {!hasSession ? (
-        <EmptyState title={t("budgets.empty.noSessionTitle")} description={t("budgets.empty.noSessionDesc")} />
-      ) : loading && !summary ? (
-        <div className="grid gap-3 sm:gap-4 grid-cols-1 sm:grid-cols-2 xl:grid-cols-4">
-          {Array.from({ length: 8 }).map((_, i) => (
-            <Card key={i}><CardContent className="p-4"><div className="h-4 w-24 bg-muted rounded" /><div className="h-6 w-32 bg-muted rounded mt-2" /></CardContent></Card>
-          ))}
         </div>
-      ) : !summary || !kpis ? (
-        <EmptyState title={t("budgets.empty.title")} description={t("budgets.empty.desc")} />
-      ) : (
-        <>
-          {/* KPIs */}
-          <div className="grid gap-3 sm:gap-4 grid-cols-1 sm:grid-cols-2 xl:grid-cols-4">
-            <KpiCard label={t("budgets.kpi.opening")} value={fmtEUR(kpis.opening, i18n.language)} />
-            <KpiCard label={t("budgets.kpi.plannedIn")} value={fmtEUR(kpis.plannedIn, i18n.language)} tone="good" />
-            <KpiCard label={t("budgets.kpi.plannedOut")} value={fmtEUR(kpis.plannedOut, i18n.language)} tone="bad" />
-            <KpiCard label={t("budgets.kpi.netPlanned")} value={fmtEUR(kpis.netPlanned, i18n.language)} tone={kpis.netPlanned >= 0 ? "good" : "bad"} hint={t("budgets.hints.netPlanned")} />
+      }
+    />
 
-            <KpiCard label={t("budgets.kpi.projectedEnd")} value={fmtEUR(kpis.projectedEndBalance, i18n.language)} />
-            <KpiCard label={t("budgets.kpi.actualIn")} value={fmtEUR(kpis.actualIn, i18n.language)} tone="good" />
-            <KpiCard label={t("budgets.kpi.actualOut")} value={fmtEUR(kpis.actualOut, i18n.language)} tone="bad" />
-            <KpiCard label={t("budgets.kpi.netActual")} value={fmtEUR(kpis.netActual, i18n.language)} tone={kpis.netActual >= 0 ? "good" : "bad"} />
-
-            <KpiCard label={t("budgets.kpi.ending")} value={fmtEUR(kpis.endingBalance, i18n.language)} />
-            <KpiCard label={t("budgets.kpi.clearedIn")} value={fmtEUR(kpis.clearedIn, i18n.language)} tone="good" />
-            <KpiCard label={t("budgets.kpi.clearedOut")} value={fmtEUR(kpis.clearedOut, i18n.language)} tone="bad" />
-            <KpiCard label={t("budgets.kpi.netCleared")} value={fmtEUR(kpis.netCleared, i18n.language)} tone={kpis.netCleared >= 0 ? "good" : "bad"} />
-          </div>
-
-          {/* Notes */}
-          <Card className="mt-2">
+    {!hasSession ? (
+      <EmptyState title={t("budgets.empty.noSessionTitle")} description={t("budgets.empty.noSessionDesc")} />
+    ) : loading && !summary ? (
+      <div className="grid gap-3 sm:gap-4 grid-cols-1 sm:grid-cols-2">
+        {Array.from({ length: 2 }).map((_, i) => (
+          <Card key={i}>
             <CardContent className="p-4">
-              <div className="text-xs uppercase tracking-wide text-muted-foreground">{t("budgets.notes.titleShort")}</div>
-              <div className="mt-1 text-sm text-foreground whitespace-pre-wrap min-h-[1.5rem]">
-                {budgetMeta?.notes ?? t("budgets.notes.empty")}
-              </div>
+              <div className="h-4 w-28 bg-muted rounded" />
+              <div className="h-8 w-40 bg-muted rounded mt-2" />
+              <div className="h-10 w-full bg-muted rounded mt-3" />
             </CardContent>
           </Card>
-        </>
-      )}
+        ))}
+      </div>
+    ) : !summary || !kpis ? (
+      <EmptyState title={t("budgets.empty.title")} description={t("budgets.empty.desc")} />
+    ) : (
+      <>
+        {/* HERO */}
+        <HeroSummary
+          title={
+            mode === "planned"
+              ? t("budgets.hero.projected")
+              : mode === "actual"
+              ? t("budgets.hero.ending")
+              : t("budgets.hero.clearedEnding")
+          }
+          main={
+            mode === "planned"
+              ? fmtEUR(kpis.projectedEndBalance, i18n.language)
+              : mode === "actual"
+              ? fmtEUR(kpis.endingBalance, i18n.language)
+              : fmtEUR(kpis.clearedEndingBalance, i18n.language)
+          }
+          tone={
+            (mode === "planned" ? kpis.netPlanned : mode === "actual" ? kpis.netActual : kpis.netCleared) >= 0
+              ? "good"
+              : "bad"
+          }
+          rows={
+            mode === "planned"
+              ? [
+                  { label: t("budgets.rows.opening"), value: fmtEUR(kpis.opening, i18n.language) },
+                  { label: t("budgets.rows.in"), value: fmtEUR(kpis.plannedIn, i18n.language), tone: "good" },
+                  { label: t("budgets.rows.out"), value: fmtEUR(kpis.plannedOut, i18n.language), tone: "bad" },
+                  { label: t("budgets.rows.net"), value: fmtEUR(kpis.netPlanned, i18n.language), tone: kpis.netPlanned >= 0 ? "good" : "bad" },
+                ]
+              : mode === "actual"
+              ? [
+                  { label: t("budgets.rows.opening"), value: fmtEUR(kpis.opening, i18n.language) },
+                  { label: t("budgets.rows.in"), value: fmtEUR(kpis.actualIn, i18n.language), tone: "good" },
+                  { label: t("budgets.rows.out"), value: fmtEUR(kpis.actualOut, i18n.language), tone: "bad" },
+                  { label: t("budgets.rows.net"), value: fmtEUR(kpis.netActual, i18n.language), tone: kpis.netActual >= 0 ? "good" : "bad" },
+                ]
+              : [
+                  { label: t("budgets.rows.in"), value: fmtEUR(kpis.clearedIn, i18n.language), tone: "good" },
+                  { label: t("budgets.rows.out"), value: fmtEUR(kpis.clearedOut, i18n.language), tone: "bad" },
+                  { label: t("budgets.rows.net"), value: fmtEUR(kpis.netCleared, i18n.language), tone: kpis.netCleared >= 0 ? "good" : "bad" },
+                  { label: t("budgets.rows.base"), value: fmtEUR(kpis.endingBalance, i18n.language) },
+                ]
+          }
+        />
 
-      {/* Dialogs */}
-      {summary && (
-        <>
-          <EditOpeningDialog
-            open={openOpening}
-            onOpenChange={setOpenOpening}
-            initial={summary.openingBalance}
-            onSave={async (n) => { await updateOpening(n); await reloadMeta(); }}
-            disabled={locked}
+        {/* COMPARAISONS */}
+        <div className="grid gap-3 sm:gap-4 grid-cols-1 sm:grid-cols-2">
+          <CompareTile
+            title={t("budgets.compare.inflow")}
+            leftLabel="Planned"
+            leftValue={fmtEUR(kpis.plannedIn, i18n.language)}
+            rightLabel="Actual"
+            rightValue={fmtEUR(kpis.actualIn, i18n.language)}
           />
-          <EditNotesDialog
-            open={openNotes}
-            onOpenChange={setOpenNotes}
-            initial={(summary as any).notes ?? null}
-            onSave={async (txt) => { await updateNotes(txt); await reloadMeta(); }}
-            disabled={locked}
+          <CompareTile
+            title={t("budgets.compare.outflow")}
+            leftLabel="Planned"
+            leftValue={fmtEUR(kpis.plannedOut, i18n.language)}
+            rightLabel="Actual"
+            rightValue={fmtEUR(kpis.actualOut, i18n.language)}
           />
-        </>
-      )}
-    </section>
-  );
+        </div>
+
+        {/* NOTES */}
+        <Card>
+          <CardContent className="p-4">
+            <div className="text-xs uppercase tracking-wide text-muted-foreground">{t("budgets.notes.titleShort")}</div>
+            <div className="mt-1 text-sm text-foreground whitespace-pre-wrap min-h-[1.5rem]">
+              {summary?.budget?.notes ?? t("budgets.notes.empty")}
+            </div>
+          </CardContent>
+        </Card>
+      </>
+    )}
+
+    {/* Dialogs */}
+    {summary && (
+      <>
+        <EditOpeningDialog
+          open={openOpening}
+          onOpenChange={setOpenOpening}
+          initial={summary.openingBalance}
+          onSave={async (n) => { await updateOpening(n); await reloadMeta(); }}
+          disabled={locked}
+        />
+        <EditNotesDialog
+          open={openNotes}
+          onOpenChange={setOpenNotes}
+          initial={budgetMeta?.notes ?? null}
+          onSave={async (txt) => { await updateNotes(txt); await reloadMeta(); }}
+          disabled={locked}
+        />
+      </>
+    )}
+  </section>
+);
 }

--- a/src/pages/budgets/index.tsx
+++ b/src/pages/budgets/index.tsx
@@ -1,25 +1,156 @@
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useSessionStore } from "@/stores/sessionStore";
 import PageHeader from "@/components/system/PageHeader";
 import EmptyState from "@/components/system/EmptyState";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import MonthPicker from "@/components/budgets/MonthPicker";
+import KpiCard from "@/components/budgets/KpiCard";
+import EditOpeningDialog from "@/components/budgets/EditOpeningDialog";
+import EditNotesDialog from "@/components/budgets/EditNotesDialog";
+import { Lock, Unlock, Pencil } from "lucide-react";
+import { useBudgetSummary } from "@/hooks/useBudgetSummary";
+import { useSessionStore } from "@/stores/sessionStore";
+import { useBudgetsService } from "@/lib/service/budget.service";
+import type { Budget } from "@/types";
+import { toast } from "sonner";
+
+function fmtEUR(v: number, lang: string) {
+  return new Intl.NumberFormat(lang, { style: "currency", currency: "EUR" }).format(v);
+}
 
 export default function BudgetsPage() {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const { currentSessionId } = useSessionStore();
+  const hasSession = !!currentSessionId;
+
+  const { month, setMonth, goPrevMonth, goNextMonth, summary, kpis, loading, lock, unlock, updateOpening, updateNotes } =
+    useBudgetSummary();
+
+  // Récupérer meta budget (lock state) — car non présent dans BudgetSummary
+  const { getByMonth } = useBudgetsService();
+  const [budgetMeta, setBudgetMeta] = useState<Budget | null>(null);
+  async function reloadMeta() {
+    if (!currentSessionId) return setBudgetMeta(null);
+    try {
+      const b = await getByMonth(currentSessionId, month);
+      setBudgetMeta(b);
+    } catch {
+      setBudgetMeta(null);
+    }
+  }
+  useEffect(() => { void reloadMeta(); /* au mount/chgt de mois/session */ }, [currentSessionId, month]);
+
+  // Dialogs
+  const [openOpening, setOpenOpening] = useState(false);
+  const [openNotes, setOpenNotes] = useState(false);
+
+  const locked = !!budgetMeta?.locked;
+
+  async function onToggleLock() {
+    try {
+      if (locked) { await unlock(); toast.success(t("budgets.toasts.unlocked")); }
+      else { await lock(); toast.success(t("budgets.toasts.locked")); }
+    } finally {
+      await reloadMeta();
+    }
+  }
+
   return (
-    <section className="p-3 sm:p-4 lg:p-6 space-y-3 sm:space-y-4 lg:space-y-6">
+    <section className="p-3 sm:p-4 lg:p-6 space-y-4">
       <PageHeader
         title={t("nav.budgets")}
         description={
-          currentSessionId
+          hasSession
             ? t("pages.common.sessionBound", { id: currentSessionId })
             : t("pages.common.noSession")
         }
+        right={
+          <div className="flex flex-wrap gap-2">
+            <MonthPicker
+              month={month}
+              onPrev={goPrevMonth}
+              onNext={goNextMonth}
+              onChange={(m) => setMonth(m)}
+              disabled={!hasSession}
+            />
+            <Button variant={locked ? "secondary" : "outline"} onClick={onToggleLock} disabled={!hasSession}>
+              {locked ? <Unlock className="h-4 w-4 mr-2" /> : <Lock className="h-4 w-4 mr-2" />}
+              {locked ? t("budgets.actions.unlock") : t("budgets.actions.lock")}
+            </Button>
+            <Button variant="outline" onClick={() => setOpenOpening(true)} disabled={!hasSession || locked}>
+              <Pencil className="h-4 w-4 mr-2" />
+              {t("budgets.actions.editOpening")}
+            </Button>
+            <Button variant="outline" onClick={() => setOpenNotes(true)} disabled={!hasSession || locked}>
+              <Pencil className="h-4 w-4 mr-2" />
+              {t("budgets.actions.editNotes")}
+            </Button>
+          </div>
+        }
       />
-      <EmptyState
-        title={t("pages.common.emptyTitle")}
-        description={t("pages.common.emptyDesc")}
-      />
+
+      {!hasSession ? (
+        <EmptyState title={t("budgets.empty.noSessionTitle")} description={t("budgets.empty.noSessionDesc")} />
+      ) : loading && !summary ? (
+        <div className="grid gap-3 sm:gap-4 grid-cols-1 sm:grid-cols-2 xl:grid-cols-4">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <Card key={i}><CardContent className="p-4"><div className="h-4 w-24 bg-muted rounded" /><div className="h-6 w-32 bg-muted rounded mt-2" /></CardContent></Card>
+          ))}
+        </div>
+      ) : !summary || !kpis ? (
+        <EmptyState title={t("budgets.empty.title")} description={t("budgets.empty.desc")} />
+      ) : (
+        <>
+          {/* KPIs */}
+          <div className="grid gap-3 sm:gap-4 grid-cols-1 sm:grid-cols-2 xl:grid-cols-4">
+            <KpiCard label={t("budgets.kpi.opening")} value={fmtEUR(kpis.opening, i18n.language)} />
+            <KpiCard label={t("budgets.kpi.plannedIn")} value={fmtEUR(kpis.plannedIn, i18n.language)} tone="good" />
+            <KpiCard label={t("budgets.kpi.plannedOut")} value={fmtEUR(kpis.plannedOut, i18n.language)} tone="bad" />
+            <KpiCard label={t("budgets.kpi.netPlanned")} value={fmtEUR(kpis.netPlanned, i18n.language)} tone={kpis.netPlanned >= 0 ? "good" : "bad"} hint={t("budgets.hints.netPlanned")} />
+
+            <KpiCard label={t("budgets.kpi.projectedEnd")} value={fmtEUR(kpis.projectedEndBalance, i18n.language)} />
+            <KpiCard label={t("budgets.kpi.actualIn")} value={fmtEUR(kpis.actualIn, i18n.language)} tone="good" />
+            <KpiCard label={t("budgets.kpi.actualOut")} value={fmtEUR(kpis.actualOut, i18n.language)} tone="bad" />
+            <KpiCard label={t("budgets.kpi.netActual")} value={fmtEUR(kpis.netActual, i18n.language)} tone={kpis.netActual >= 0 ? "good" : "bad"} />
+
+            <KpiCard label={t("budgets.kpi.ending")} value={fmtEUR(kpis.endingBalance, i18n.language)} />
+            <KpiCard label={t("budgets.kpi.clearedIn")} value={fmtEUR(kpis.clearedIn, i18n.language)} tone="good" />
+            <KpiCard label={t("budgets.kpi.clearedOut")} value={fmtEUR(kpis.clearedOut, i18n.language)} tone="bad" />
+            <KpiCard label={t("budgets.kpi.netCleared")} value={fmtEUR(kpis.netCleared, i18n.language)} tone={kpis.netCleared >= 0 ? "good" : "bad"} />
+          </div>
+
+          {/* Notes */}
+          <Card className="mt-2">
+            <CardContent className="p-4">
+              <div className="text-xs uppercase tracking-wide text-muted-foreground">{t("budgets.notes.titleShort")}</div>
+              <div className="mt-1 text-sm text-foreground whitespace-pre-wrap min-h-[1.5rem]">
+                {budgetMeta?.notes ?? t("budgets.notes.empty")}
+              </div>
+            </CardContent>
+          </Card>
+        </>
+      )}
+
+      {/* Dialogs */}
+      {summary && (
+        <>
+          <EditOpeningDialog
+            open={openOpening}
+            onOpenChange={setOpenOpening}
+            initial={summary.openingBalance}
+            onSave={async (n) => { await updateOpening(n); await reloadMeta(); }}
+            disabled={locked}
+          />
+          <EditNotesDialog
+            open={openNotes}
+            onOpenChange={setOpenNotes}
+            initial={(summary as any).notes ?? null}
+            onSave={async (txt) => { await updateNotes(txt); await reloadMeta(); }}
+            disabled={locked}
+          />
+        </>
+      )}
     </section>
   );
 }

--- a/src/types/budgets.ts
+++ b/src/types/budgets.ts
@@ -25,7 +25,7 @@ export type UpdateBudgetDto = Partial<Pick<Budget, "openingBalance" | "notes" | 
 export type BudgetSummary = {
   sessionId: string;
   month: MonthString;
-  budget?: BudgetId | null      // présent si un budget existe déjà
+  budget?: Budget | null      // présent si un budget existe déjà
   openingBalance: string;         // "1234.56"
   plannedIncome: string;          // agrégé depuis incomes/expenses
   plannedExpense: string;         // agrégé depuis incomes/expenses

--- a/src/types/budgets.ts
+++ b/src/types/budgets.ts
@@ -1,0 +1,42 @@
+export type MonthString = `${number}-${string}`; // "YYYY-MM"
+
+export type BudgetId = string;
+
+export type Budget = {
+  id: BudgetId;
+  sessionId: string;
+  month: MonthString;             // "YYYY-MM"
+  openingBalance: string;         // API convention: string "1234.56"
+  notes?: string | null;
+  locked?: boolean;               // lock/unlock
+  createdAt?: string;
+  updatedAt?: string;
+};
+
+export type CreateBudgetDto = {
+  sessionId: string;
+  month: MonthString;
+  openingBalance: string;         // "1234.56"
+  notes?: string | null;
+};
+
+export type UpdateBudgetDto = Partial<Pick<Budget, "openingBalance" | "notes" | "locked">>;
+
+export type BudgetSummary = {
+  sessionId: string;
+  month: MonthString;
+  budget?: BudgetId | null      // présent si un budget existe déjà
+  openingBalance: string;         // "1234.56"
+  plannedIncome: string;          // agrégé depuis incomes/expenses
+  plannedExpense: string;         // agrégé depuis incomes/expenses
+  netPlanned: string;              // plannedIncome - plannedExpense
+  projectedEndBalance: string;    // openingBalance + netPlanned
+  actualInFlow: string;                 // agrégé depuis transactions
+  actualOutFlow: string;                // agrégé depuis transactions
+  netActual: string;                     // actualInFlow - actualOutFlow
+  endingBalance: string;                 // projectedEndBalance + netActual
+  clearedInFlow: string;                   // agrégé depuis transactions
+  clearedOutFlow: string;                  // agrégé depuis transactions
+  netCleared: string;                     // clearedInFlow - clearedOutFlow
+  clearedEndingBalance: string;          // endingBalance + netCleared
+};

--- a/src/types/budgets.ts
+++ b/src/types/budgets.ts
@@ -1,4 +1,4 @@
-export type MonthString = `${number}-${string}`; // "YYYY-MM"
+export type MonthString = string // "YYYY-MM"
 
 export type BudgetId = string;
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,3 +3,4 @@ export * from "./sessions";
 export * from "./banks";
 export * from "./incomes";
 export * from "./expenses";
+export * from "./budgets";


### PR DESCRIPTION
### 1) Résumé

* Page **/dashboard/budgets** affichant le **résumé du mois** de la session active, avec **fallback auto** s’il n’existe pas.
* **UI** refondue : un **Hero** (valeur de clôture principale) + **onglets** Planned/Actual/Cleared + **comparatifs** simples (Entrées/Sorties) + **Notes**.
* **Actions** : modifier **solde d’ouverture**, **notes**, **lock/unlock**.
* **Robustesse** : si aucun budget n’existe, le front **crée** d’abord le budget (via hook) puis patch.

### 2) Arborescence/fichiers

```
src/
├─ types/
│  └─ budgets.ts                        # Budget, BudgetSummary (summary.budget: Budget | null)
├─ lib/service/
│  └─ budgets.service.ts                 # list/getByMonth/create/update/remove/getSummary
├─ hooks/
│  └─ useBudgetSummary.ts                # session-aware, month ±1, createIfMissing, getOrCreateBudget, actions
├─ components/budgets/
│  ├─ MonthPicker.tsx
│  ├─ ModeTabs.tsx
│  ├─ HeroSummary.tsx
│  └─ CompareTile.tsx
├─ components/budgets/
│  ├─ EditOpeningDialog.tsx              # RHF + zod (number), reset sur open
│  └─ EditNotesDialog.tsx
└─ pages/budgets/
   └─ index.tsx                          # Hero + tabs + comparatifs + notes + actions
```

### 3) Types (source front)

* `BudgetSummary` avec **champs plats** (`plannedIncome`, `netPlanned`, `projectedEndBalance`, `actualInFlow`, `endingBalance`, `cleared*`) + `budget?: Budget | null`.
* Montants **string** côté API.

### 4) Service `useBudgetsService()`

* `getSummary(sessionId, month, {createIfMissing})` (source principale).
* `getByMonth(sessionId, month)`, `create()`, `update(budgetId, patch)`, `remove(budgetId)`.
* **Hardening** : `update/remove` normalisent l’id (évite `/budgets/[object Object]`).

### 5) Hook `useBudgetSummary()`

* Charge **1×** par changement session/mois (garde `inFlight`).
* `ensureBudgetIdOrCreate()` → lit l’ID via summary/GET, sinon **crée** et **synchronise** `summary.budget` (objet `Budget`).
* Actions : `updateOpening`, `updateNotes`, `lock`, `unlock` → `PATCH` puis `refresh()`.
* Expose `getOrCreateBudget()` pour l’UI (pas de 404).
* `kpis` numériques prêts pour le rendu.

### 6) UI

* **Hero** : affiche **Projected Closing / Closing / Cleared Closing** selon l’onglet.
* **Sous-lignes** : Ouverture, In, Out, Net (signalisées).
* **Comparatifs** : Planned ↔ Actual (Entrées/Sorties).
* **Notes**, **Lock/Unlock**, **Edit ouverture/notes**.
* **Responsive** mobile-first (grids 1→2).

### 7) Scénarios & attentes

1. Mois sans budget → modifier ouverture ⇒ **création** + patch + refresh.
2. Notes idem.
3. Lock/Unlock → succès + refresh, boutons de saisie **désactivés** en lock.
4. Navigation mois ±1 → 1 fetch propre.
5. Jamais d’URL `/budgets/[object Object]`.

### 8) DoD

* [x] Résumé mois courant + navigation.
* [x] Fallback auto + création transparente.
* [x] Édition ouverture/notes + lock/unlock.
* [x] UI claire, responsive, i18n.
* [x] Build/typecheck OK, pas de régression J0–J7.
