### PR TITLE
feat(j9-transactions): UI + hooks + filtres + cleared + CSV

### DIFF
--- a/src/components/transactions/TransactionCardItem.tsx
+++ b/src/components/transactions/TransactionCardItem.tsx
@@ -38,7 +38,7 @@ export default function TransactionCardItem({ tx, onEdit, onDelete, onToggleClea
             {tx.isCleared && <Badge variant="secondary">Cleared</Badge>}
           </div>
           <div className="flex items-center gap-2">
-            <Switch checked={!!tx.isCleared} onCheckedChange={() => onToggleCleared(tx)} />
+            <Switch aria-label={`Toggle cleared: ${tx.label}`} checked={!!tx.isCleared} onCheckedChange={() => onToggleCleared(tx)} />
             <Button size="icon" variant="outline" onClick={() => onEdit(tx)}><Pencil className="h-4 w-4" /></Button>
             <Button size="icon" variant="destructive" onClick={() => onDelete(tx)}><Trash2 className="h-4 w-4" /></Button>
           </div>

--- a/src/components/transactions/TransactionCardItem.tsx
+++ b/src/components/transactions/TransactionCardItem.tsx
@@ -1,0 +1,49 @@
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
+import { Pencil, Trash2 } from "lucide-react";
+import type { Transaction } from "@/types";
+
+type Props = {
+  tx: Transaction;
+  onEdit: (tx: Transaction) => void;
+  onDelete: (tx: Transaction) => void;
+  onToggleCleared: (tx: Transaction) => void;
+  fmt: (n: number | string) => string;
+};
+
+export default function TransactionCardItem({ tx, onEdit, onDelete, onToggleCleared, fmt }: Props) {
+  const isOut = tx.type === "OUTFLOW";
+  const tone = isOut ? "text-rose-600 dark:text-rose-400" : "text-emerald-600 dark:text-emerald-400";
+  return (
+    <Card>
+      <CardContent className="p-4 space-y-2">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <div className="text-sm font-medium truncate">{tx.label}</div>
+            <div className="text-xs text-muted-foreground">{tx.date}</div>
+            <div className="mt-1 text-xs text-muted-foreground truncate">
+              {tx.bankAccountId}{tx.memberId ? ` • ${tx.memberId}` : ""}
+            </div>
+          </div>
+          <div className={`text-base font-semibold whitespace-nowrap ${tone}`}>
+            {fmt(tx.amount)}
+          </div>
+        </div>
+
+        <div className="flex items-center justify-between gap-2">
+          <div className="flex items-center gap-2">
+            {tx.category && <Badge variant="outline">{tx.category}</Badge>}
+            {tx.isCleared && <Badge variant="secondary">Cleared</Badge>}
+          </div>
+          <div className="flex items-center gap-2">
+            <Switch checked={!!tx.isCleared} onCheckedChange={() => onToggleCleared(tx)} />
+            <Button size="icon" variant="outline" onClick={() => onEdit(tx)}><Pencil className="h-4 w-4" /></Button>
+            <Button size="icon" variant="destructive" onClick={() => onDelete(tx)}><Trash2 className="h-4 w-4" /></Button>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/transactions/TransactionFormDialog.tsx
+++ b/src/components/transactions/TransactionFormDialog.tsx
@@ -1,0 +1,235 @@
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useTranslation } from "react-i18next";
+import {
+  Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import type { Transaction, TransactionCategory, TransactionType } from "@/types";
+
+const schema = z.object({
+  type: z.enum(["INFLOW", "OUTFLOW"] as const),
+  date: z.string().min(10, "Date invalide"),
+  label: z.string().trim().min(1, "Libellé requis"),
+  amount: z.coerce.number().positive("Montant > 0"),
+  bankAccountId: z.string().min(1, "Compte requis"),
+  memberId: z.string().optional().or(z.literal("")),
+  notes: z.string().optional().nullable(),
+  category: z.string().optional().nullable(),
+});
+type FormValues = z.infer<typeof schema>;
+type Option = { id: string; label: string };
+
+type Props = {
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+  mode: "create" | "edit";
+  initial?: Partial<Transaction> | null;
+  bankOptions: Option[];
+  memberOptions?: Option[];
+  onSubmit: (values: Omit<FormValues, "memberId" | "category" | "notes"> & {
+    memberId?: string | null;
+    category?: TransactionCategory | null;
+    notes?: string | null;
+  }) => Promise<void> | void;
+  disabled?: boolean;
+};
+
+// sentinelles
+const NONE = "__NONE__";
+const NO_BANK = "__NO_BANK__";
+
+export default function TransactionFormDialog({
+  open, onOpenChange, mode, initial, bankOptions, memberOptions = [], onSubmit, disabled
+}: Props) {
+  const { t } = useTranslation();
+
+  const safeBanks = (bankOptions ?? []).filter(o => o.id && o.id.trim() !== "");
+  const firstBank = safeBanks[0]?.id ?? NO_BANK;
+
+const {
+  register, handleSubmit, reset, setValue, watch,
+  formState: { errors, isSubmitting }
+} = useForm<FormValues>({
+  resolver: zodResolver(schema) as any,
+  defaultValues: {
+    type: (initial?.type as TransactionType) ?? "OUTFLOW",
+    date: initial?.date ?? new Date().toISOString().slice(0, 10),
+    label: initial?.label ?? "",
+    amount: typeof initial?.amount === "number"
+      ? initial?.amount
+      : Number(String(initial?.amount ?? "0").replace(",", ".")),
+    bankAccountId: initial?.bankAccountId ?? firstBank,
+    memberId: initial?.memberId ?? "",
+    notes: initial?.notes ?? "",
+    category: (initial as any)?.category ?? "",
+  },
+});
+
+  // Re-populate à l’ouverture (ou changement initial)
+useEffect(() => {
+  if (!open) return;
+  reset({
+    type: (initial?.type as TransactionType) ?? "OUTFLOW",
+    date: initial?.date ?? new Date().toISOString().slice(0, 10),
+    label: initial?.label ?? "",
+    amount: typeof initial?.amount === "number"
+      ? initial?.amount
+      : Number(String(initial?.amount ?? "0").replace(",", ".")),
+    bankAccountId: initial?.bankAccountId ?? firstBank,
+    memberId: initial?.memberId ?? "",
+    notes: initial?.notes ?? "",
+    category: (initial as any)?.category ?? "",
+  });
+}, [open, initial?.id]);
+
+  const type = watch("type");
+
+  async function onSubmitInternal(v: FormValues) {
+    await onSubmit({
+      ...v,
+      memberId: v.memberId ? v.memberId : undefined,
+      category: (v.category as TransactionCategory) || undefined,
+      notes: v.notes ?? undefined,
+    });
+    onOpenChange(false);
+  }
+
+  const bankVal = watch("bankAccountId") || firstBank;
+  const memberVal = (watch("memberId") || "") as string;
+  const categoryVal = (watch("category") || "") as string;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg max-w-[calc(100vw-1.5rem)]">
+        <DialogHeader>
+          <DialogTitle>
+            {mode === "create" ? t("tx.form.titleCreate") : t("tx.form.titleEdit")}
+          </DialogTitle>
+          <DialogDescription>{t("tx.form.description")}</DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit(onSubmitInternal)} className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          {/* Type */}
+          <div className="space-y-1">
+            <Label>{t("tx.form.type")}</Label>
+            <Select
+              value={watch("type")}
+              onValueChange={(val) => setValue("type", val as any)}
+              disabled={disabled}
+            >
+              <SelectTrigger><SelectValue placeholder="Type" /></SelectTrigger>
+              <SelectContent>
+                <SelectItem value="INFLOW">{t("tx.types.inflow")}</SelectItem>
+                <SelectItem value="OUTFLOW">{t("tx.types.outflow")}</SelectItem>
+              </SelectContent>
+            </Select>
+            {errors.type && <p className="text-xs text-destructive">{String(errors.type.message)}</p>}
+          </div>
+
+          {/* Date */}
+          <div className="space-y-1">
+            <Label>{t("tx.form.date")}</Label>
+            <Input type="date" className="h-9" disabled={disabled} {...register("date")} />
+            {errors.date && <p className="text-xs text-destructive">{String(errors.date.message)}</p>}
+          </div>
+
+          {/* Libellé */}
+          <div className="space-y-1 sm:col-span-2">
+            <Label>{t("tx.form.label")}</Label>
+            <Input className="h-9" placeholder={t("tx.form.labelPh") ?? ""} disabled={disabled} {...register("label")} />
+            {errors.label && <p className="text-xs text-destructive">{String(errors.label.message)}</p>}
+          </div>
+
+          {/* Montant */}
+          <div className="space-y-1">
+            <Label>{t("tx.form.amount")}</Label>
+            <Input className="h-9" inputMode="decimal" placeholder="0.00" disabled={disabled} {...register("amount")} />
+            {errors.amount && <p className="text-xs text-destructive">{String(errors.amount.message)}</p>}
+          </div>
+
+          {/* Compte bancaire (aucune valeur vide; fallback NO_BANK désactivé) */}
+          <div className="space-y-1">
+            <Label>{t("tx.form.bank")}</Label>
+            <Select
+              value={bankVal}
+              onValueChange={(val) => setValue("bankAccountId", val)}
+              disabled={disabled || safeBanks.length === 0}
+            >
+              <SelectTrigger><SelectValue placeholder={t("tx.form.bankPh") ?? ""} /></SelectTrigger>
+              <SelectContent>
+                {safeBanks.length === 0 ? (
+                  <SelectItem value={NO_BANK} disabled>{t("tx.form.bankPh") ?? "Aucun compte disponible"}</SelectItem>
+                ) : (
+                  safeBanks.map((o) => <SelectItem key={o.id} value={o.id}>{o.label}</SelectItem>)
+                )}
+              </SelectContent>
+            </Select>
+            {errors.bankAccountId && <p className="text-xs text-destructive">{String(errors.bankAccountId.message)}</p>}
+          </div>
+
+          {/* Membre (sentinelle NONE) */}
+          <div className="space-y-1">
+            <Label>{t("tx.form.member")}</Label>
+            <Select
+              value={memberVal || NONE}
+              onValueChange={(val) => setValue("memberId", val === NONE ? "" : val)}
+              disabled={disabled || (memberOptions ?? []).length === 0}
+            >
+              <SelectTrigger><SelectValue placeholder={t("tx.form.memberPh") ?? ""} /></SelectTrigger>
+              <SelectContent>
+                <SelectItem value={NONE}>{t("tx.form.memberNone")}</SelectItem>
+                {(memberOptions ?? []).filter(o => o.id && o.id.trim() !== "").map((o) => (
+                  <SelectItem key={o.id} value={o.id}>{o.label}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* Catégorie (sentinelle NONE, activée si OUTFLOW) */}
+          <div className="space-y-1">
+            <Label>{t("tx.form.category")}</Label>
+            <Select
+              value={categoryVal || NONE}
+              onValueChange={(val) => setValue("category", val === NONE ? "" : val)}
+              disabled={disabled || type !== "OUTFLOW"}
+            >
+              <SelectTrigger><SelectValue placeholder={t("tx.form.categoryPh") ?? ""} /></SelectTrigger>
+              <SelectContent>
+                <SelectItem value={NONE}>{t("tx.form.categoryNone")}</SelectItem>
+                <SelectItem value="FOOD">{t("categories.FOOD")}</SelectItem>
+                <SelectItem value="HOUSING">{t("categories.HOUSING")}</SelectItem>
+                <SelectItem value="UTILITIES">{t("categories.UTILITIES")}</SelectItem>
+                <SelectItem value="HEALTH">{t("categories.HEALTH")}</SelectItem>
+                <SelectItem value="TRANSPORT">{t("categories.TRANSPORT")}</SelectItem>
+                <SelectItem value="SUBSCRIPTIONS">{t("categories.SUBSCRIPTIONS")}</SelectItem>
+                <SelectItem value="OTHER">{t("categories.OTHER")}</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* Notes */}
+          <div className="space-y-1 sm:col-span-2">
+            <Label>{t("tx.form.notes")}</Label>
+            <Textarea rows={3} disabled={disabled} {...register("notes")} />
+          </div>
+
+          <DialogFooter className="sm:col-span-2 flex flex-col sm:flex-row gap-2">
+            <Button type="button" variant="secondary" className="w-full sm:w-auto" onClick={() => onOpenChange(false)}>
+              {t("common.cancel")}
+            </Button>
+            <Button type="submit" className="w-full sm:w-auto" disabled={isSubmitting || disabled}>
+              {mode === "create" ? t("common.create") : t("common.save")}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/transactions/TransactionsSkeleton.tsx
+++ b/src/components/transactions/TransactionsSkeleton.tsx
@@ -1,0 +1,46 @@
+// src/components/transactions/TransactionsSkeleton.tsx
+import { Card, CardContent } from "@/components/ui/card";
+
+export function FiltersSkeleton() {
+  return (
+    <Card>
+      <CardContent className="p-4 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="space-y-2">
+            <div className="h-3 w-20 bg-muted rounded" />
+            <div className="h-9 w-full bg-muted rounded" />
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}
+
+export function ListSkeleton() {
+  return (
+    <div className="space-y-3">
+      {Array.from({ length: 6 }).map((_, i) => (
+        <Card key={i}>
+          <CardContent className="p-4 space-y-2">
+            <div className="flex items-center justify-between">
+              <div className="h-4 w-40 bg-muted rounded" />
+              <div className="h-5 w-24 bg-muted rounded" />
+            </div>
+            <div className="h-3 w-28 bg-muted rounded" />
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}
+
+export function TableSkeleton() {
+  return (
+    <div className="hidden sm:block">
+      <div className="h-7 w-full bg-muted rounded mb-2" />
+      {Array.from({ length: 8 }).map((_, i) => (
+        <div key={i} className="h-10 w-full bg-muted/70 rounded mb-2" />
+      ))}
+    </div>
+  );
+}

--- a/src/hooks/useDebouncedValue.ts
+++ b/src/hooks/useDebouncedValue.ts
@@ -1,0 +1,11 @@
+// src/hooks/useDebouncedValue.ts
+import { useEffect, useState } from "react";
+
+export function useDebouncedValue<T>(value: T, delay = 300) {
+  const [v, setV] = useState<T>(value);
+  useEffect(() => {
+    const t = setTimeout(() => setV(value), delay);
+    return () => clearTimeout(t);
+  }, [value, delay]);
+  return v;
+}

--- a/src/hooks/useTransactions.ts
+++ b/src/hooks/useTransactions.ts
@@ -1,0 +1,193 @@
+// src/hooks/useTransactions.ts
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useSessionStore } from "@/stores/sessionStore";
+import { useTransactionsService } from "@/lib/service/transaction.service";
+import type {
+  DateRange,
+  MonthRange,
+  Transaction,
+  TransactionId,
+  CreateTransactionDto,
+  UpdateTransactionDto,
+  MonthString,
+} from "@/types";
+
+function monthToRange(month: MonthString): DateRange {
+  // month: "YYYY-MM"
+  const [y, m] = month.split("-").map(Number);
+  const from = new Date(y, m - 1, 1);
+  const to = new Date(y, m, 0); // last day of month
+  const iso = (d: Date) => d.toISOString().slice(0, 10);
+  return { from: iso(from), to: iso(to) };
+}
+function toMoneyString(v: number | string) {
+  const n = typeof v === "number" ? v : Number(String(v).replace(",", "."));
+  const safe = Number.isFinite(n) ? n : 0;
+  return safe.toFixed(2);
+}
+
+type ClearedFilter = "ALL" | "CLEARED" | "UNCLEARED";
+
+export function useTransactions(input?: Partial<DateRange & MonthRange>) {
+  const { currentSessionId } = useSessionStore();
+  const svc = useTransactionsService();
+
+  // Stabiliser méthodes (StrictMode)
+  const listRef = useRef(svc.listBySession);
+  const createRef = useRef(svc.create);
+  const updateRef = useRef(svc.update);
+  const removeRef = useRef(svc.remove);
+  useEffect(() => {
+    listRef.current = svc.listBySession;
+    createRef.current = svc.create;
+    updateRef.current = svc.update;
+    removeRef.current = svc.remove;
+  }, [svc]);
+
+  // Période : priorité à {from,to}, sinon {month}, sinon mois courant
+  const [range, setRange] = useState<DateRange>(() => {
+    if (input?.from && input?.to) return { from: input.from, to: input.to };
+    const month: MonthString =
+      (input as any)?.month ??
+      `${new Date().getFullYear()}-${String(new Date().getMonth() + 1).padStart(2, "0")}`;
+    return monthToRange(month);
+  });
+  const setMonth = useCallback((m: MonthString) => setRange(monthToRange(m)), []);
+
+  // Filtres client
+  const [bankAccountId, setBankAccountId] = useState<string | null>(null);
+  const [memberId, setMemberId] = useState<string | null>(null);
+  const [cleared, setCleared] = useState<ClearedFilter>("ALL");
+  const [query, setQuery] = useState<string>("");
+
+  // Données
+  const [items, setItems] = useState<Transaction[]>([]);
+  const [loading, setLoading] = useState(false);
+  const inFlight = useRef(false);
+
+  const refresh = useCallback(async () => {
+    if (!currentSessionId) return;
+    if (inFlight.current) return;
+    inFlight.current = true;
+    setLoading(true);
+    try {
+      const list = await listRef.current(currentSessionId, {
+        from: range.from,
+        to: range.to,
+      });
+      setItems(Array.isArray(list) ? list : []);
+    } finally {
+      setLoading(false);
+      inFlight.current = false;
+    }
+  }, [currentSessionId, range.from, range.to]);
+
+  useEffect(() => {
+    void refresh(); // mount + changement de période/session
+  }, [refresh]);
+
+  // Helpers CRUD
+  const createTx = useCallback(
+    async (data: Omit<CreateTransactionDto, "amount" | "sessionId"> & { amount: number | string }) => {
+      if (!currentSessionId) return null;
+      const dto: CreateTransactionDto = {
+        ...data,
+        sessionId: currentSessionId,
+        amount: toMoneyString(data.amount),
+      };
+      const created = await createRef.current(dto);
+      await refresh();
+      return created;
+    },
+    [currentSessionId, refresh]
+  );
+
+  const updateTx = useCallback(
+    async (
+        id: TransactionId,
+        data: { amount?: number | string } & Omit<UpdateTransactionDto, "amount">
+    ) => {
+        const { amount, ...rest } = data; // <-- on retire amount du spread
+        const dto: UpdateTransactionDto = {
+        ...rest,
+        ...(amount !== undefined ? { amount: toMoneyString(amount) } : {}),
+        };
+        const updated = await updateRef.current(id, dto);
+        await refresh();
+        return updated;
+    },
+    [refresh]
+  );
+
+  const toggleCleared = useCallback(
+    async (id: TransactionId, current?: boolean) => {
+      const updated = await updateRef.current(id, { isCleared: !current });
+      await refresh();
+      return updated;
+    },
+    [refresh]
+  );
+
+  const removeTx = useCallback(
+    async (id: TransactionId) => {
+      await removeRef.current(id);
+      await refresh();
+    },
+    [refresh]
+  );
+
+  // Dérivés filtrés/sortis
+  const visible = useMemo(() => {
+    let rows = items.slice();
+    if (bankAccountId) rows = rows.filter((r) => r.bankAccountId === bankAccountId);
+    if (memberId) rows = rows.filter((r) => r.memberId === memberId);
+    if (cleared !== "ALL") rows = rows.filter((r) => !!r.isCleared === (cleared === "CLEARED"));
+    if (query.trim()) {
+      const q = query.trim().toLowerCase();
+      rows = rows.filter((r) => r.label?.toLowerCase().includes(q) || r.notes?.toLowerCase().includes(q));
+    }
+    // Tri date DESC puis id DESC
+    rows.sort((a, b) => (a.date < b.date ? 1 : a.date > b.date ? -1 : a.id < b.id ? 1 : -1));
+    return rows;
+  }, [items, bankAccountId, memberId, cleared, query]);
+
+  // Totaux de la période filtrée (client)
+  const totals = useMemo(() => {
+    return visible.reduce(
+      (acc, t) => {
+        const n = typeof t.amount === "number" ? t.amount : Number(String(t.amount).replace(",", "."));
+        const val = Number.isFinite(n) ? n : 0;
+        if (t.type === "INFLOW") acc.in += val;
+        else acc.out += val;
+        return acc;
+      },
+      { in: 0, out: 0 }
+    );
+  }, [visible]);
+
+  return {
+    // état
+    items,
+    visible,     // liste filtrée/triée pour l’UI
+    loading,
+    range,
+    setRange,
+    setMonth,
+
+    // filtres
+    bankAccountId, setBankAccountId,
+    memberId, setMemberId,
+    cleared, setCleared,
+    query, setQuery,
+
+    // actions
+    refresh,
+    createTx,
+    updateTx,
+    toggleCleared,
+    removeTx,
+
+    // totaux
+    totals,
+  };
+}

--- a/src/hooks/useTxUrlState.ts
+++ b/src/hooks/useTxUrlState.ts
@@ -1,0 +1,44 @@
+// src/hooks/useTxUrlState.ts
+import { useCallback, useMemo } from "react";
+import { useSearchParams } from "react-router-dom";
+
+export type ClearedFilter = "ALL" | "CLEARED" | "UNCLEARED";
+
+type State = {
+  month?: string | null;      // "YYYY-MM"
+  bank?: string | null;
+  member?: string | null;
+  cleared?: ClearedFilter;
+  q?: string | null;
+};
+
+function getOrNull(v: string | null) {
+  return v && v.length ? v : null;
+}
+
+export function useTxUrlState(defaults?: Required<State>) {
+  const [sp, setSp] = useSearchParams();
+
+  const state: Required<State> = useMemo(() => {
+    return {
+      month: getOrNull(sp.get("month")) ?? defaults?.month ?? "",
+      bank: getOrNull(sp.get("bank")) ?? null,
+      member: getOrNull(sp.get("member")) ?? null,
+      cleared: (getOrNull(sp.get("cleared")) as ClearedFilter) ?? (defaults?.cleared ?? "ALL"),
+      q: getOrNull(sp.get("q")) ?? "",
+    };
+  }, [sp, defaults]);
+
+  const set = useCallback((next: Partial<State>, opts?: { replace?: boolean }) => {
+    const n = new URLSearchParams(sp);
+    const entries: [keyof State, any][] = Object.entries(next) as any;
+    for (const [k, v] of entries) {
+      if (v === undefined) continue;
+      if (v === null || v === "" || (k === "cleared" && v === "ALL")) n.delete(k);
+      else n.set(k, String(v));
+    }
+    setSp(n, { replace: opts?.replace ?? true });
+  }, [sp, setSp]);
+
+  return [state, set] as const;
+}

--- a/src/i18n/resources/en.json
+++ b/src/i18n/resources/en.json
@@ -71,7 +71,8 @@
     "cancel": "Cancel",
     "delete": "Delete",
     "save": "Save",
-    "edit": "Edit"
+    "edit": "Edit",
+    "refresh": "Refresh"
   },
   "sessions": {
     "selector": {
@@ -451,6 +452,9 @@
     "delete": {
       "title": "Delete transaction?",
       "desc": "This action cannot be undone."
+    },
+    "a11y": {
+      "toggleCleared": "Toggle cleared: {{label}}"
     }
   },
   "categories": {

--- a/src/i18n/resources/en.json
+++ b/src/i18n/resources/en.json
@@ -400,5 +400,66 @@
       "inflow": "Inflow comparison",
       "outflow": "Outflow comparison"
     }
+  },
+  "tx": {
+    "actions": { "new": "New transaction" },
+    "filters": {
+      "search": "Search",
+      "searchPh": "Label or note…",
+      "bank": "Account",
+      "bankPh": "Select an account",
+      "member": "Member",
+      "memberPh": "Select a member",
+      "any": "Any",
+      "cleared": "Cleared",
+      "clearedAll": "All",
+      "clearedYes": "Cleared",
+      "clearedNo": "Uncleared"
+    },
+    "totals": { "in": "Inflow", "out": "Outflow", "net": "Net" },
+    "table": {
+      "date": "Date", "label": "Label", "account": "Account",
+      "member": "Member", "amount": "Amount", "category": "Category",
+      "cleared": "Cleared", "actions": "Actions"
+    },
+    "form": {
+      "titleCreate": "Create transaction",
+      "titleEdit": "Edit transaction",
+      "description": "Fill in the fields below.",
+      "type": "Type",
+      "date": "Date",
+      "label": "Label",
+      "labelPh": "e.g. Groceries, transfer, salary…",
+      "amount": "Amount",
+      "bank": "Bank account",
+      "bankPh": "Select an account",
+      "member": "Member",
+      "memberPh": "Select a member",
+      "memberNone": "None",
+      "category": "Category",
+      "categoryPh": "Category (optional)",
+      "categoryNone": "None",
+      "notes": "Notes"
+    },
+    "types": { "inflow": "Inflow", "outflow": "Outflow" },
+    "empty": {
+      "noSessionTitle": "No active session",
+      "noSessionDesc": "Select or create a session to manage transactions.",
+      "title": "No transactions",
+      "desc": "Create your first transaction this month."
+    },
+    "delete": {
+      "title": "Delete transaction?",
+      "desc": "This action cannot be undone."
+    }
+  },
+  "categories": {
+    "FOOD": "Food",
+    "HOUSING": "Housing",
+    "UTILITIES": "Utilities",
+    "HEALTH": "Health",
+    "TRANSPORT": "Transport",
+    "SUBSCRIPTIONS": "Subscriptions",
+    "OTHER": "Other"
   }
 }

--- a/src/i18n/resources/fr.json
+++ b/src/i18n/resources/fr.json
@@ -71,7 +71,8 @@
     "cancel": "Annuler",
     "delete": "Supprimer",
     "save": "Enregistrer",
-    "edit": "Éditer"
+    "edit": "Éditer",
+    "refresh": "Rafraîchir"
   },
   "sessions": {
     "selector": {
@@ -452,6 +453,9 @@
     "delete": {
       "title": "Supprimer la transaction ?",
       "desc": "Cette action est irréversible."
+    },
+    "a11y": {
+      "toggleCleared": "Basculer pointage : {{label}}"
     }
   },
   "categories": {

--- a/src/i18n/resources/fr.json
+++ b/src/i18n/resources/fr.json
@@ -401,5 +401,66 @@
       "inflow": "Comparatif Entrées",
       "outflow": "Comparatif Sorties"
     }
+  },
+  "tx": {
+    "actions": { "new": "Nouvelle transaction" },
+    "filters": {
+      "search": "Recherche",
+      "searchPh": "Libellé ou note…",
+      "bank": "Compte",
+      "bankPh": "Choisir un compte",
+      "member": "Membre",
+      "memberPh": "Choisir un membre",
+      "any": "Tous",
+      "cleared": "Pointage",
+      "clearedAll": "Tous",
+      "clearedYes": "Pointées",
+      "clearedNo": "Non pointées"
+    },
+    "totals": { "in": "Entrées", "out": "Sorties", "net": "Net" },
+    "table": {
+      "date": "Date", "label": "Libellé", "account": "Compte",
+      "member": "Membre", "amount": "Montant", "category": "Catégorie",
+      "cleared": "Pointée", "actions": "Actions"
+    },
+    "form": {
+      "titleCreate": "Créer une transaction",
+      "titleEdit": "Modifier la transaction",
+      "description": "Renseigne les informations ci-dessous.",
+      "type": "Type",
+      "date": "Date",
+      "label": "Libellé",
+      "labelPh": "Ex: Courses, virement, salaire…",
+      "amount": "Montant",
+      "bank": "Compte bancaire",
+      "bankPh": "Sélectionne un compte",
+      "member": "Membre",
+      "memberPh": "Sélectionne un membre",
+      "memberNone": "Aucun",
+      "category": "Catégorie",
+      "categoryPh": "Catégorie (facultatif)",
+      "categoryNone": "Aucune",
+      "notes": "Notes"
+    },
+    "types": { "inflow": "Entrée", "outflow": "Sortie" },
+    "empty": {
+      "noSessionTitle": "Aucune session active",
+      "noSessionDesc": "Sélectionne ou crée une session pour gérer tes transactions.",
+      "title": "Aucune transaction",
+      "desc": "Crée ta première transaction ce mois-ci."
+    },
+    "delete": {
+      "title": "Supprimer la transaction ?",
+      "desc": "Cette action est irréversible."
+    }
+  },
+  "categories": {
+    "FOOD": "Alimentation",
+    "HOUSING": "Logement",
+    "UTILITIES": "Charges",
+    "HEALTH": "Santé",
+    "TRANSPORT": "Transport",
+    "SUBSCRIPTIONS": "Abonnements",
+    "OTHER": "Autre"
   }
 }

--- a/src/lib/service/index.ts
+++ b/src/lib/service/index.ts
@@ -5,3 +5,4 @@ export * from "./member.service";
 export * from "./income.service";
 export * from "./expense.service";
 export * from "./budget.service";
+export * from "./transaction.service";

--- a/src/lib/service/transaction.service.ts
+++ b/src/lib/service/transaction.service.ts
@@ -1,0 +1,33 @@
+import { useApi } from "@/lib/api/useApi";
+import type {
+  CreateTransactionDto,
+  UpdateTransactionDto,
+  Transaction,
+} from "@/types";
+
+export function useTransactionsService() {
+  const { get, post, patch, del } = useApi();
+
+  // GET /transactions/session/{sessionId}[?from=YYYY-MM-DD&to=YYYY-MM-DD]
+  // (Référence API) :contentReference[oaicite:2]{index=2}
+  const listBySession = (sessionId: string, params?: { from?: string; to?: string }) => {
+    const q = new URLSearchParams();
+    if (params?.from) q.set("from", params.from);
+    if (params?.to) q.set("to", params.to);
+    const suffix = q.toString() ? `?${q.toString()}` : "";
+    return get<Transaction[]>(`/transactions/session/${sessionId}${suffix}`);
+  };
+
+  // POST /transactions (INFLOW/OUTFLOW) :contentReference[oaicite:3]{index=3}
+  const create = (dto: CreateTransactionDto) =>
+    post<Transaction>("/transactions", dto);
+
+  // PATCH /transactions/{id} (mise à jour/changement cleared) :contentReference[oaicite:4]{index=4}
+  const update = (id: string, dto: UpdateTransactionDto) =>
+    patch<Transaction>(`/transactions/${id}`, dto);
+
+  // DELETE /transactions/{id} :contentReference[oaicite:5]{index=5}
+  const remove = (id: string) => del<void>(`/transactions/${id}`);
+
+  return { listBySession, create, update, remove };
+}

--- a/src/pages/transactions/index.tsx
+++ b/src/pages/transactions/index.tsx
@@ -1,25 +1,358 @@
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useSessionStore } from "@/stores/sessionStore";
 import PageHeader from "@/components/system/PageHeader";
 import EmptyState from "@/components/system/EmptyState";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import {
+  AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent,
+  AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle
+} from "@/components/ui/alert-dialog";
+import { Card, CardContent } from "@/components/ui/card";
+import { Plus, Search, RefreshCw } from "lucide-react";
+import MonthPicker from "@/components/budgets/MonthPicker";
+import TransactionFormDialog from "@/components/transactions/TransactionFormDialog";
+import TransactionCardItem from "@/components/transactions/TransactionCardItem";
+import { useTransactions } from "@/hooks/useTransactions";
+import { useSessionStore } from "@/stores/sessionStore";
+import { useBanks } from "@/hooks/useBanks";
+import { useSessionService } from "@/lib/service/session.service";
+import type { Transaction, TransactionCategory } from "@/types";
+
+// utils
+function fmtEUR(v: number | string, lang: string) {
+  const n = typeof v === "number" ? v : Number(String(v).replace(",", "."));
+  return new Intl.NumberFormat(lang, { style: "currency", currency: "EUR" }).format(Number.isFinite(n) ? n : 0);
+}
+function prevMonth(current: string, delta: -1 | 1) {
+  const [y, m] = current.split("-").map(Number);
+  const d = new Date(y, (m - 1) + delta, 1);
+  const yy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  return `${yy}-${mm}`;
+}
+
+type Option = { id: string; label: string };
+
+// sentinelles interdites aux chaînes vides
+const ANY = "__ANY__";
 
 export default function TransactionsPage() {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const { currentSessionId } = useSessionStore();
+
+
+  const {
+    visible, loading, range, setMonth,
+    bankAccountId, setBankAccountId,
+    memberId, setMemberId,
+    cleared, setCleared,
+    query, setQuery,
+    refresh, createTx, updateTx, toggleCleared, removeTx, totals
+  } = useTransactions();
+
+  // Comptes → options (filtrer ids vides)
+  const { banks } = useBanks();
+  const bankOptions: Option[] = (banks ?? [])
+    .map((b: any) => ({ id: String(b.id ?? ""), label: b.label ?? b.bankName ?? String(b.id ?? "") }))
+    .filter((o: Option) => o.id.trim().length > 0);
+
+  // Membres → options (fetch via service; filtrer ids vides)
+  const { getSessionMembers } = useSessionService();
+  const getSessionMembersRef = useRef(getSessionMembers);
+useEffect(() => {
+  getSessionMembersRef.current = getSessionMembers;
+}, [getSessionMembers]);
+
+const [memberOptions, setMemberOptions] = useState<Option[]>([]);
+
+useEffect(() => {
+  let alive = true;
+  async function loadMembers() {
+    if (!currentSessionId) {
+      setMemberOptions([]);
+      return;
+    }
+    try {
+      const ms = await getSessionMembersRef.current(currentSessionId);
+      if (!alive) return;
+      const opts = (ms ?? [])
+        .map((m: any) => ({
+          id: String(m.id ?? ""),
+          label: m.name ?? m.invitedEmail ?? String(m.id ?? ""),
+        }))
+        .filter((o: Option) => o.id.trim().length > 0);
+      setMemberOptions(opts);
+    } catch {
+      if (alive) setMemberOptions([]);
+    }
+  }
+  void loadMembers();
+  return () => {
+    alive = false;
+  };
+  // 🔑 Dépend uniquement de la session (pas de la ref de fonction)
+}, [currentSessionId]);
+
+  // Dialogs
+  const [openForm, setOpenForm] = useState(false);
+  const [mode, setMode] = useState<"create" | "edit">("create");
+  const [editing, setEditing] = useState<Transaction | null>(null);
+
+  // Delete confirm
+  const [confirmId, setConfirmId] = useState<string | null>(null);
+
+  const hasSession = !!currentSessionId;
+  const monthString = useMemo(() => range.from.slice(0, 7), [range.from]);
+
+  function openCreate() {
+    setMode("create");
+    setEditing(null);
+    setOpenForm(true);
+  }
+  function openEdit(tx: Transaction) {
+    setMode("edit");
+    setEditing(tx);
+    setOpenForm(true);
+  }
+
   return (
-    <section className="p-3 sm:p-4 lg:p-6 space-y-3 sm:space-y-4 lg:space-y-6">
+    <section className="p-3 sm:p-4 lg:p-6 space-y-4">
       <PageHeader
         title={t("nav.transactions")}
-        description={
-          currentSessionId
-            ? t("pages.common.sessionBound", { id: currentSessionId })
-            : t("pages.common.noSession")
+        description={hasSession ? t("pages.common.sessionBound", { id: currentSessionId }) : t("pages.common.noSession")}
+        right={
+          <div className="flex flex-col sm:flex-row gap-2 sm:items-center">
+            <MonthPicker
+              month={monthString}
+              onPrev={() => setMonth(prevMonth(monthString, -1))}
+              onNext={() => setMonth(prevMonth(monthString, +1))}
+              onChange={(m) => setMonth(m)}
+              disabled={!hasSession}
+            />
+            <Button variant="default" onClick={openCreate} disabled={!hasSession}>
+              <Plus className="h-4 w-4 mr-2" /> {t("tx.actions.new")}
+            </Button>
+            <Button variant="outline" onClick={() => refresh()} disabled={!hasSession || loading}>
+              <RefreshCw className={`h-4 w-4 mr-2 ${loading ? "animate-spin" : ""}`} /> {t("common.refresh")}
+            </Button>
+          </div>
         }
       />
-      <EmptyState
-        title={t("pages.common.emptyTitle")}
-        description={t("pages.common.emptyDesc")}
+
+      {!hasSession ? (
+        <EmptyState title={t("tx.empty.noSessionTitle")} description={t("tx.empty.noSessionDesc")} />
+      ) : (
+        <>
+          {/* Filtres */}
+          <Card>
+            <CardContent className="p-4 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
+              {/* Recherche */}
+              <div className="space-y-1">
+                <Label>{t("tx.filters.search")}</Label>
+                <div className="flex items-center gap-2">
+                  <Search className="h-4 w-4 text-muted-foreground" />
+                  <Input
+                    className="h-9"
+                    value={query}
+                    onChange={(e) => setQuery(e.target.value)}
+                    placeholder={t("tx.filters.searchPh") ?? ""}
+                  />
+                </div>
+              </div>
+
+              {/* Compte (sentinelle "__ANY__") */}
+              <div className="space-y-1">
+                <Label>{t("tx.filters.bank")}</Label>
+                <Select
+                  value={bankAccountId ?? ANY}
+                  onValueChange={(v) => setBankAccountId(v === ANY ? null : v)}
+                >
+                  <SelectTrigger><SelectValue placeholder={t("tx.filters.bankPh") ?? ""} /></SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value={ANY}>{t("tx.filters.any")}</SelectItem>
+                    {bankOptions.map((o: Option) => (
+                      <SelectItem key={o.id} value={o.id}>{o.label}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              {/* Membre (sentinelle "__ANY__") */}
+              <div className="space-y-1">
+                <Label>{t("tx.filters.member")}</Label>
+                <Select
+                  value={memberId ?? ANY}
+                  onValueChange={(v) => setMemberId(v === ANY ? null : v)}
+                >
+                  <SelectTrigger><SelectValue placeholder={t("tx.filters.memberPh") ?? ""} /></SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value={ANY}>{t("tx.filters.any")}</SelectItem>
+                    {memberOptions.map((o: Option) => (
+                      <SelectItem key={o.id} value={o.id}>{o.label}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              {/* Cleared */}
+              <div className="space-y-1">
+                <Label>{t("tx.filters.cleared")}</Label>
+                <Select value={cleared} onValueChange={(v) => setCleared(v as any)}>
+                  <SelectTrigger><SelectValue /></SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="ALL">{t("tx.filters.clearedAll")}</SelectItem>
+                    <SelectItem value="CLEARED">{t("tx.filters.clearedYes")}</SelectItem>
+                    <SelectItem value="UNCLEARED">{t("tx.filters.clearedNo")}</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Totaux */}
+          <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+            <Card>
+              <CardContent className="p-4">
+                <div className="text-xs text-muted-foreground">{t("tx.totals.in")}</div>
+                <div className="text-lg font-semibold text-emerald-600 dark:text-emerald-400">
+                  {fmtEUR(totals.in, i18n.language)}
+                </div>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardContent className="p-4">
+                <div className="text-xs text-muted-foreground">{t("tx.totals.out")}</div>
+                <div className="text-lg font-semibold text-rose-600 dark:text-rose-400">
+                  {fmtEUR(totals.out, i18n.language)}
+                </div>
+              </CardContent>
+            </Card>
+            <Card className="col-span-2 sm:col-span-1">
+              <CardContent className="p-4">
+                <div className="text-xs text-muted-foreground">{t("tx.totals.net")}</div>
+                <div className={`text-lg font-semibold ${totals.in - totals.out >= 0 ? "text-emerald-600 dark:text-emerald-400" : "text-rose-600 dark:text-rose-400"}`}>
+                  {fmtEUR(totals.in - totals.out, i18n.language)}
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+
+          {/* Liste MOBILE */}
+          <div className="grid gap-3 sm:hidden">
+            {visible.map((tx) => (
+              <TransactionCardItem
+                key={tx.id}
+                tx={tx}
+                fmt={(v) => (tx.type === "OUTFLOW" ? "-" : "+") + " " + fmtEUR(v, i18n.language)}
+                onEdit={openEdit}
+                onDelete={(t) => setConfirmId(t.id)}
+                onToggleCleared={(t) => void toggleCleared(t.id, t.isCleared)}
+              />
+            ))}
+            {visible.length === 0 && (
+              <EmptyState title={t("tx.empty.title")} description={t("tx.empty.desc")} />
+            )}
+          </div>
+
+          {/* Liste DESKTOP */}
+          <div className="hidden sm:block overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead className="text-xs text-muted-foreground">
+                <tr className="text-left border-b">
+                  <th className="py-2 pr-2">{t("tx.table.date")}</th>
+                  <th className="py-2 pr-2">{t("tx.table.label")}</th>
+                  <th className="py-2 pr-2">{t("tx.table.account")}</th>
+                  <th className="py-2 pr-2">{t("tx.table.member")}</th>
+                  <th className="py-2 pr-2">{t("tx.table.amount")}</th>
+                  <th className="py-2 pr-2">{t("tx.table.category")}</th>
+                  <th className="py-2 pr-2">{t("tx.table.cleared")}</th>
+                  <th className="py-2 pr-2 w-[120px]">{t("tx.table.actions")}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {visible.map((tx) => {
+                  const isOut = tx.type === "OUTFLOW";
+                  return (
+                    <tr key={tx.id} className="border-b">
+                      <td className="py-2 pr-2 whitespace-nowrap">{tx.date}</td>
+                      <td className="py-2 pr-2">{tx.label}</td>
+                      <td className="py-2 pr-2">{tx.bankAccountId}</td>
+                      <td className="py-2 pr-2">{tx.memberId ?? "-"}</td>
+                      <td className={`py-2 pr-2 font-medium whitespace-nowrap ${isOut ? "text-rose-600 dark:text-rose-400" : "text-emerald-600 dark:text-emerald-400"}`}>
+                        {(isOut ? "-" : "+") + " " + fmtEUR(tx.amount, i18n.language)}
+                      </td>
+                      <td className="py-2 pr-2">{(tx as any).category ?? "-"}</td>
+                      <td className="py-2 pr-2">
+                        <Switch checked={!!tx.isCleared} onCheckedChange={() => void toggleCleared(tx.id, tx.isCleared)} />
+                      </td>
+                      <td className="py-2 pr-2">
+                        <div className="flex gap-2">
+                          <Button size="sm" variant="outline" onClick={() => openEdit(tx)}>{t("common.edit")}</Button>
+                          <Button size="sm" variant="destructive" onClick={() => setConfirmId(tx.id)}>{t("common.delete")}</Button>
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+            {visible.length === 0 && (
+              <div className="py-6">
+                <EmptyState title={t("tx.empty.title")} description={t("tx.empty.desc")} />
+              </div>
+            )}
+          </div>
+        </>
+      )}
+
+      {/* Dialog create/edit */}
+      <TransactionFormDialog
+        open={openForm}
+        onOpenChange={setOpenForm}
+        mode={mode}
+        initial={editing}
+        bankOptions={bankOptions}
+        memberOptions={memberOptions}
+        onSubmit={async (v) => {
+          const base = {
+            type: v.type,
+            date: v.date,
+            label: v.label,
+            amount: v.amount,
+            bankAccountId: v.bankAccountId,
+          };
+          const optMember = v.memberId ? { memberId: v.memberId } : {};
+          const optCategory = v.category ? { category: v.category as TransactionCategory } : {};
+          const optNotes = v.notes ? { notes: v.notes } : {};
+
+          if (mode === "create") {
+            await createTx({ ...base, ...optMember, ...optCategory, ...optNotes });
+          } else if (editing) {
+            await updateTx(editing.id, { ...base, ...optMember, ...optCategory, ...optNotes });
+          }
+        }}
       />
+
+      {/* Confirm delete */}
+      <AlertDialog open={!!confirmId} onOpenChange={(o) => !o && setConfirmId(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t("tx.delete.title")}</AlertDialogTitle>
+            <AlertDialogDescription>{t("tx.delete.desc")}</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel onClick={() => setConfirmId(null)}>{t("common.cancel")}</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={async () => { if (confirmId) await removeTx(confirmId); setConfirmId(null); }}>
+              {t("common.delete")}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </section>
   );
 }

--- a/src/pages/transactions/index.tsx
+++ b/src/pages/transactions/index.tsx
@@ -5,11 +5,23 @@ import EmptyState from "@/components/system/EmptyState";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
 import {
-  AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent,
-  AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { Card, CardContent } from "@/components/ui/card";
 import { Plus, Search, RefreshCw } from "lucide-react";
@@ -21,15 +33,25 @@ import { useSessionStore } from "@/stores/sessionStore";
 import { useBanks } from "@/hooks/useBanks";
 import { useSessionService } from "@/lib/service/session.service";
 import type { Transaction, TransactionCategory } from "@/types";
+import { useTxUrlState } from "@/hooks/useTxUrlState";
+import { useDebouncedValue } from "@/hooks/useDebouncedValue";
+import {
+  FiltersSkeleton,
+  ListSkeleton,
+  TableSkeleton,
+} from "@/components/transactions/TransactionsSkeleton";
 
 // utils
 function fmtEUR(v: number | string, lang: string) {
   const n = typeof v === "number" ? v : Number(String(v).replace(",", "."));
-  return new Intl.NumberFormat(lang, { style: "currency", currency: "EUR" }).format(Number.isFinite(n) ? n : 0);
+  return new Intl.NumberFormat(lang, {
+    style: "currency",
+    currency: "EUR",
+  }).format(Number.isFinite(n) ? n : 0);
 }
 function prevMonth(current: string, delta: -1 | 1) {
   const [y, m] = current.split("-").map(Number);
-  const d = new Date(y, (m - 1) + delta, 1);
+  const d = new Date(y, m - 1 + delta, 1);
   const yy = d.getFullYear();
   const mm = String(d.getMonth() + 1).padStart(2, "0");
   return `${yy}-${mm}`;
@@ -44,58 +66,73 @@ export default function TransactionsPage() {
   const { t, i18n } = useTranslation();
   const { currentSessionId } = useSessionStore();
 
-
   const {
-    visible, loading, range, setMonth,
-    bankAccountId, setBankAccountId,
-    memberId, setMemberId,
-    cleared, setCleared,
-    query, setQuery,
-    refresh, createTx, updateTx, toggleCleared, removeTx, totals
+    visible,
+    items,
+    loading,
+    range,
+    setMonth,
+    bankAccountId,
+    setBankAccountId,
+    memberId,
+    setMemberId,
+    cleared,
+    setCleared,
+    query,
+    setQuery,
+    refresh,
+    createTx,
+    updateTx,
+    toggleCleared,
+    removeTx,
+    totals,
   } = useTransactions();
 
   // Comptes → options (filtrer ids vides)
   const { banks } = useBanks();
   const bankOptions: Option[] = (banks ?? [])
-    .map((b: any) => ({ id: String(b.id ?? ""), label: b.label ?? b.bankName ?? String(b.id ?? "") }))
+    .map((b: any) => ({
+      id: String(b.id ?? ""),
+      label: b.label ?? b.bankName ?? String(b.id ?? ""),
+    }))
     .filter((o: Option) => o.id.trim().length > 0);
 
   // Membres → options (fetch via service; filtrer ids vides)
   const { getSessionMembers } = useSessionService();
   const getSessionMembersRef = useRef(getSessionMembers);
-useEffect(() => {
-  getSessionMembersRef.current = getSessionMembers;
-}, [getSessionMembers]);
+  useEffect(() => {
+    getSessionMembersRef.current = getSessionMembers;
+  }, [getSessionMembers]);
 
-const [memberOptions, setMemberOptions] = useState<Option[]>([]);
+  const [memberOptions, setMemberOptions] = useState<Option[]>([]);
 
-useEffect(() => {
-  let alive = true;
-  async function loadMembers() {
-    if (!currentSessionId) {
-      setMemberOptions([]);
-      return;
+  useEffect(() => {
+    let alive = true;
+    async function loadMembers() {
+      if (!currentSessionId) {
+        setMemberOptions([]);
+        return;
+      }
+      try {
+        const ms = await getSessionMembersRef.current(currentSessionId);
+        if (!alive) return;
+        const opts = (ms ?? [])
+          .map((m: any) => ({
+            id: String(m.id ?? ""),
+            label: m.name ?? m.invitedEmail ?? String(m.id ?? ""),
+          }))
+          .filter((o: Option) => o.id.trim().length > 0);
+        setMemberOptions(opts);
+      } catch {
+        if (alive) setMemberOptions([]);
+      }
     }
-    try {
-      const ms = await getSessionMembersRef.current(currentSessionId);
-      if (!alive) return;
-      const opts = (ms ?? [])
-        .map((m: any) => ({
-          id: String(m.id ?? ""),
-          label: m.name ?? m.invitedEmail ?? String(m.id ?? ""),
-        }))
-        .filter((o: Option) => o.id.trim().length > 0);
-      setMemberOptions(opts);
-    } catch {
-      if (alive) setMemberOptions([]);
-    }
-  }
-  void loadMembers();
-  return () => {
-    alive = false;
-  };
-  // 🔑 Dépend uniquement de la session (pas de la ref de fonction)
-}, [currentSessionId]);
+    void loadMembers();
+    return () => {
+      alive = false;
+    };
+    // 🔑 Dépend uniquement de la session (pas de la ref de fonction)
+  }, [currentSessionId]);
 
   // Dialogs
   const [openForm, setOpenForm] = useState(false);
@@ -119,11 +156,100 @@ useEffect(() => {
     setOpenForm(true);
   }
 
+  // URL <-> état
+  const [url, setUrl] = useTxUrlState({
+    month: monthString,
+    bank: bankAccountId ?? null,
+    member: memberId ?? null,
+    cleared,
+    q: query,
+  });
+
+  // Champ de recherche "contrôlé" avec debounce
+  const [queryInput, setQueryInput] = useState(query);
+  const debouncedQuery = useDebouncedValue(queryInput, 350);
+
+  // 1) À l’arrivée sur la page ou navigation Back/Forward : pousse URL -> états
+  useEffect(() => {
+    if (url.month && url.month !== monthString) setMonth(url.month);
+    setBankAccountId(url.bank ?? null);
+    setMemberId(url.member ?? null);
+    setCleared(url.cleared);
+    setQuery(url.q ?? "");
+    setQueryInput(url.q ?? "");
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [url.month, url.bank, url.member, url.cleared, url.q]);
+
+  // 2) Quand l’utilisateur change des filtres : états -> URL
+  useEffect(() => {
+    setUrl({
+      month: monthString,
+      bank: bankAccountId ?? null,
+      member: memberId ?? null,
+      cleared,
+      q: debouncedQuery ?? "",
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [monthString, bankAccountId, memberId, cleared, debouncedQuery]);
+
+  // 3) Appliquer la recherche debounced au hook data
+  useEffect(() => {
+    setQuery(debouncedQuery ?? "");
+  }, [debouncedQuery, setQuery]);
+
+  function exportCsv(rows: Transaction[]) {
+    const head = [
+      "id",
+      "date",
+      "type",
+      "label",
+      "amount",
+      "bankAccountId",
+      "memberId",
+      "category",
+      "isCleared",
+      "notes",
+    ];
+    const esc = (v: any) => {
+      if (v === null || v === undefined) return "";
+      const s = String(v).replace(/"/g, '""');
+      return `"${s}"`;
+    };
+    const body = rows.map((r) =>
+      [
+        r.id,
+        r.date,
+        r.type,
+        r.label,
+        typeof r.amount === "number" ? r.amount.toFixed(2) : r.amount,
+        r.bankAccountId,
+        r.memberId ?? "",
+        (r as any).category ?? "",
+        r.isCleared ? "1" : "0",
+        r.notes ?? "",
+      ]
+        .map(esc)
+        .join(",")
+    );
+    const csv = [head.join(","), ...body].join("\n");
+    const blob = new Blob([csv], { type: "text/csv;charset=utf-8" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `transactions_${new Date().toISOString().slice(0, 10)}.csv`;
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+
   return (
     <section className="p-3 sm:p-4 lg:p-6 space-y-4">
       <PageHeader
         title={t("nav.transactions")}
-        description={hasSession ? t("pages.common.sessionBound", { id: currentSessionId }) : t("pages.common.noSession")}
+        description={
+          hasSession
+            ? t("pages.common.sessionBound", { id: currentSessionId })
+            : t("pages.common.noSession")
+        }
         right={
           <div className="flex flex-col sm:flex-row gap-2 sm:items-center">
             <MonthPicker
@@ -133,18 +259,47 @@ useEffect(() => {
               onChange={(m) => setMonth(m)}
               disabled={!hasSession}
             />
-            <Button variant="default" onClick={openCreate} disabled={!hasSession}>
+            <Button
+              variant="default"
+              onClick={openCreate}
+              disabled={!hasSession}
+            >
               <Plus className="h-4 w-4 mr-2" /> {t("tx.actions.new")}
             </Button>
-            <Button variant="outline" onClick={() => refresh()} disabled={!hasSession || loading}>
-              <RefreshCw className={`h-4 w-4 mr-2 ${loading ? "animate-spin" : ""}`} /> {t("common.refresh")}
+            <Button
+              variant="outline"
+              onClick={() => refresh()}
+              disabled={!hasSession || loading}
+            >
+              <RefreshCw
+                className={`h-4 w-4 mr-2 ${loading ? "animate-spin" : ""}`}
+              />{" "}
+              {t("common.refresh")}
+            </Button>
+            <Button
+              variant="outline"
+              onClick={() => exportCsv(visible)}
+              disabled={!hasSession || visible.length === 0}
+            >
+              CSV
             </Button>
           </div>
         }
       />
 
       {!hasSession ? (
-        <EmptyState title={t("tx.empty.noSessionTitle")} description={t("tx.empty.noSessionDesc")} />
+        <EmptyState
+          title={t("tx.empty.noSessionTitle")}
+          description={t("tx.empty.noSessionDesc")}
+        />
+      ) : loading && items.length === 0 ? (
+        <>
+          <FiltersSkeleton />
+          <div className="sm:hidden">
+            <ListSkeleton />
+          </div>
+          <TableSkeleton />
+        </>
       ) : (
         <>
           {/* Filtres */}
@@ -157,8 +312,8 @@ useEffect(() => {
                   <Search className="h-4 w-4 text-muted-foreground" />
                   <Input
                     className="h-9"
-                    value={query}
-                    onChange={(e) => setQuery(e.target.value)}
+                    value={queryInput}
+                    onChange={(e) => setQueryInput(e.target.value)}
                     placeholder={t("tx.filters.searchPh") ?? ""}
                   />
                 </div>
@@ -171,11 +326,15 @@ useEffect(() => {
                   value={bankAccountId ?? ANY}
                   onValueChange={(v) => setBankAccountId(v === ANY ? null : v)}
                 >
-                  <SelectTrigger><SelectValue placeholder={t("tx.filters.bankPh") ?? ""} /></SelectTrigger>
+                  <SelectTrigger>
+                    <SelectValue placeholder={t("tx.filters.bankPh") ?? ""} />
+                  </SelectTrigger>
                   <SelectContent>
                     <SelectItem value={ANY}>{t("tx.filters.any")}</SelectItem>
                     {bankOptions.map((o: Option) => (
-                      <SelectItem key={o.id} value={o.id}>{o.label}</SelectItem>
+                      <SelectItem key={o.id} value={o.id}>
+                        {o.label}
+                      </SelectItem>
                     ))}
                   </SelectContent>
                 </Select>
@@ -188,11 +347,15 @@ useEffect(() => {
                   value={memberId ?? ANY}
                   onValueChange={(v) => setMemberId(v === ANY ? null : v)}
                 >
-                  <SelectTrigger><SelectValue placeholder={t("tx.filters.memberPh") ?? ""} /></SelectTrigger>
+                  <SelectTrigger>
+                    <SelectValue placeholder={t("tx.filters.memberPh") ?? ""} />
+                  </SelectTrigger>
                   <SelectContent>
                     <SelectItem value={ANY}>{t("tx.filters.any")}</SelectItem>
                     {memberOptions.map((o: Option) => (
-                      <SelectItem key={o.id} value={o.id}>{o.label}</SelectItem>
+                      <SelectItem key={o.id} value={o.id}>
+                        {o.label}
+                      </SelectItem>
                     ))}
                   </SelectContent>
                 </Select>
@@ -201,12 +364,23 @@ useEffect(() => {
               {/* Cleared */}
               <div className="space-y-1">
                 <Label>{t("tx.filters.cleared")}</Label>
-                <Select value={cleared} onValueChange={(v) => setCleared(v as any)}>
-                  <SelectTrigger><SelectValue /></SelectTrigger>
+                <Select
+                  value={cleared}
+                  onValueChange={(v) => setCleared(v as any)}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="ALL">{t("tx.filters.clearedAll")}</SelectItem>
-                    <SelectItem value="CLEARED">{t("tx.filters.clearedYes")}</SelectItem>
-                    <SelectItem value="UNCLEARED">{t("tx.filters.clearedNo")}</SelectItem>
+                    <SelectItem value="ALL">
+                      {t("tx.filters.clearedAll")}
+                    </SelectItem>
+                    <SelectItem value="CLEARED">
+                      {t("tx.filters.clearedYes")}
+                    </SelectItem>
+                    <SelectItem value="UNCLEARED">
+                      {t("tx.filters.clearedNo")}
+                    </SelectItem>
                   </SelectContent>
                 </Select>
               </div>
@@ -214,10 +388,15 @@ useEffect(() => {
           </Card>
 
           {/* Totaux */}
-          <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+          <div
+            className="grid grid-cols-2 sm:grid-cols-3 gap-3"
+            aria-live="polite"
+          >
             <Card>
               <CardContent className="p-4">
-                <div className="text-xs text-muted-foreground">{t("tx.totals.in")}</div>
+                <div className="text-xs text-muted-foreground">
+                  {t("tx.totals.in")}
+                </div>
                 <div className="text-lg font-semibold text-emerald-600 dark:text-emerald-400">
                   {fmtEUR(totals.in, i18n.language)}
                 </div>
@@ -225,7 +404,9 @@ useEffect(() => {
             </Card>
             <Card>
               <CardContent className="p-4">
-                <div className="text-xs text-muted-foreground">{t("tx.totals.out")}</div>
+                <div className="text-xs text-muted-foreground">
+                  {t("tx.totals.out")}
+                </div>
                 <div className="text-lg font-semibold text-rose-600 dark:text-rose-400">
                   {fmtEUR(totals.out, i18n.language)}
                 </div>
@@ -233,8 +414,16 @@ useEffect(() => {
             </Card>
             <Card className="col-span-2 sm:col-span-1">
               <CardContent className="p-4">
-                <div className="text-xs text-muted-foreground">{t("tx.totals.net")}</div>
-                <div className={`text-lg font-semibold ${totals.in - totals.out >= 0 ? "text-emerald-600 dark:text-emerald-400" : "text-rose-600 dark:text-rose-400"}`}>
+                <div className="text-xs text-muted-foreground">
+                  {t("tx.totals.net")}
+                </div>
+                <div
+                  className={`text-lg font-semibold ${
+                    totals.in - totals.out >= 0
+                      ? "text-emerald-600 dark:text-emerald-400"
+                      : "text-rose-600 dark:text-rose-400"
+                  }`}
+                >
                   {fmtEUR(totals.in - totals.out, i18n.language)}
                 </div>
               </CardContent>
@@ -247,14 +436,21 @@ useEffect(() => {
               <TransactionCardItem
                 key={tx.id}
                 tx={tx}
-                fmt={(v) => (tx.type === "OUTFLOW" ? "-" : "+") + " " + fmtEUR(v, i18n.language)}
+                fmt={(v) =>
+                  (tx.type === "OUTFLOW" ? "-" : "+") +
+                  " " +
+                  fmtEUR(v, i18n.language)
+                }
                 onEdit={openEdit}
                 onDelete={(t) => setConfirmId(t.id)}
                 onToggleCleared={(t) => void toggleCleared(t.id, t.isCleared)}
               />
             ))}
             {visible.length === 0 && (
-              <EmptyState title={t("tx.empty.title")} description={t("tx.empty.desc")} />
+              <EmptyState
+                title={t("tx.empty.title")}
+                description={t("tx.empty.desc")}
+              />
             )}
           </div>
 
@@ -270,7 +466,9 @@ useEffect(() => {
                   <th className="py-2 pr-2">{t("tx.table.amount")}</th>
                   <th className="py-2 pr-2">{t("tx.table.category")}</th>
                   <th className="py-2 pr-2">{t("tx.table.cleared")}</th>
-                  <th className="py-2 pr-2 w-[120px]">{t("tx.table.actions")}</th>
+                  <th className="py-2 pr-2 w-[120px]">
+                    {t("tx.table.actions")}
+                  </th>
                 </tr>
               </thead>
               <tbody>
@@ -282,17 +480,47 @@ useEffect(() => {
                       <td className="py-2 pr-2">{tx.label}</td>
                       <td className="py-2 pr-2">{tx.bankAccountId}</td>
                       <td className="py-2 pr-2">{tx.memberId ?? "-"}</td>
-                      <td className={`py-2 pr-2 font-medium whitespace-nowrap ${isOut ? "text-rose-600 dark:text-rose-400" : "text-emerald-600 dark:text-emerald-400"}`}>
-                        {(isOut ? "-" : "+") + " " + fmtEUR(tx.amount, i18n.language)}
+                      <td
+                        className={`py-2 pr-2 font-medium whitespace-nowrap ${
+                          isOut
+                            ? "text-rose-600 dark:text-rose-400"
+                            : "text-emerald-600 dark:text-emerald-400"
+                        }`}
+                      >
+                        {(isOut ? "-" : "+") +
+                          " " +
+                          fmtEUR(tx.amount, i18n.language)}
                       </td>
-                      <td className="py-2 pr-2">{(tx as any).category ?? "-"}</td>
                       <td className="py-2 pr-2">
-                        <Switch checked={!!tx.isCleared} onCheckedChange={() => void toggleCleared(tx.id, tx.isCleared)} />
+                        {(tx as any).category ?? "-"}
+                      </td>
+                      <td className="py-2 pr-2">
+                        <Switch
+                          aria-label={t("tx.a11y.toggleCleared", {
+                            label: tx.label,
+                          })}
+                          checked={!!tx.isCleared}
+                          onCheckedChange={() =>
+                            void toggleCleared(tx.id, tx.isCleared)
+                          }
+                        />
                       </td>
                       <td className="py-2 pr-2">
                         <div className="flex gap-2">
-                          <Button size="sm" variant="outline" onClick={() => openEdit(tx)}>{t("common.edit")}</Button>
-                          <Button size="sm" variant="destructive" onClick={() => setConfirmId(tx.id)}>{t("common.delete")}</Button>
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            onClick={() => openEdit(tx)}
+                          >
+                            {t("common.edit")}
+                          </Button>
+                          <Button
+                            size="sm"
+                            variant="destructive"
+                            onClick={() => setConfirmId(tx.id)}
+                          >
+                            {t("common.delete")}
+                          </Button>
                         </div>
                       </td>
                     </tr>
@@ -302,7 +530,10 @@ useEffect(() => {
             </table>
             {visible.length === 0 && (
               <div className="py-6">
-                <EmptyState title={t("tx.empty.title")} description={t("tx.empty.desc")} />
+                <EmptyState
+                  title={t("tx.empty.title")}
+                  description={t("tx.empty.desc")}
+                />
               </div>
             )}
           </div>
@@ -326,28 +557,51 @@ useEffect(() => {
             bankAccountId: v.bankAccountId,
           };
           const optMember = v.memberId ? { memberId: v.memberId } : {};
-          const optCategory = v.category ? { category: v.category as TransactionCategory } : {};
+          const optCategory = v.category
+            ? { category: v.category as TransactionCategory }
+            : {};
           const optNotes = v.notes ? { notes: v.notes } : {};
 
           if (mode === "create") {
-            await createTx({ ...base, ...optMember, ...optCategory, ...optNotes });
+            await createTx({
+              ...base,
+              ...optMember,
+              ...optCategory,
+              ...optNotes,
+            });
           } else if (editing) {
-            await updateTx(editing.id, { ...base, ...optMember, ...optCategory, ...optNotes });
+            await updateTx(editing.id, {
+              ...base,
+              ...optMember,
+              ...optCategory,
+              ...optNotes,
+            });
           }
         }}
       />
 
       {/* Confirm delete */}
-      <AlertDialog open={!!confirmId} onOpenChange={(o) => !o && setConfirmId(null)}>
+      <AlertDialog
+        open={!!confirmId}
+        onOpenChange={(o) => !o && setConfirmId(null)}
+      >
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>{t("tx.delete.title")}</AlertDialogTitle>
-            <AlertDialogDescription>{t("tx.delete.desc")}</AlertDialogDescription>
+            <AlertDialogDescription>
+              {t("tx.delete.desc")}
+            </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel onClick={() => setConfirmId(null)}>{t("common.cancel")}</AlertDialogCancel>
+            <AlertDialogCancel onClick={() => setConfirmId(null)}>
+              {t("common.cancel")}
+            </AlertDialogCancel>
             <AlertDialogAction
-              onClick={async () => { if (confirmId) await removeTx(confirmId); setConfirmId(null); }}>
+              onClick={async () => {
+                if (confirmId) await removeTx(confirmId);
+                setConfirmId(null);
+              }}
+            >
               {t("common.delete")}
             </AlertDialogAction>
           </AlertDialogFooter>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,3 +4,4 @@ export * from "./banks";
 export * from "./incomes";
 export * from "./expenses";
 export * from "./budgets";
+export * from "./transactions";

--- a/src/types/transactions.ts
+++ b/src/types/transactions.ts
@@ -1,0 +1,50 @@
+import type { MonthString } from "@/types";
+
+export type TransactionId = string;
+export type TransactionType = "INFLOW" | "OUTFLOW";
+export type TransactionCategory =
+  | "HOUSING" | "UTILITIES" | "HEALTH" | "FOOD"
+  | "TRANSPORT" | "SUBSCRIPTIONS" | "OTHER";
+
+export type Transaction = {
+  id: TransactionId;
+  sessionId: string;
+  bankAccountId: string;
+  memberId?: string | null;
+  type: TransactionType;
+  label: string;
+  amount: string | number;       // UI peut manipuler number; API attend string
+  date: string;                  // "YYYY-MM-DD"
+  isCleared?: boolean;
+  notes?: string | null;
+  category?: TransactionCategory; // surtout pour OUTFLOW
+  createdAt?: string;
+  updatedAt?: string;
+};
+
+export type CreateTransactionDto = {
+  sessionId: string;
+  bankAccountId: string;
+  memberId?: string | null;
+  type: TransactionType;
+  label: string;
+  amount: string;                // API: "123.45"
+  date: string;                  // "YYYY-MM-DD"
+  category?: TransactionCategory;
+  isCleared?: boolean;
+  notes?: string | null;
+};
+
+export type UpdateTransactionDto = Partial<
+  Pick<
+    Transaction,
+    | "label" | "date" | "memberId" | "bankAccountId"
+    | "notes" | "isCleared" | "category" | "type"
+  >
+> & {
+  amount?: string;               // API string si présent
+};
+
+// Petit helper utile dans le hook
+export type DateRange = { from: string; to: string }; // "YYYY-MM-DD"
+export type MonthRange = { month: MonthString };       // "YYYY-MM"


### PR DESCRIPTION
## 1) Résumé

Mise en place de la fonctionnalité **Transactions** pour une session :

* **Liste** (mobile cartes / desktop table) avec **filtres** (mois, compte, membre, pointage, recherche).
* **CRUD** des transactions (Entrée/Sortie), **toggle cleared**.
* **Finitions UX** : filtres **persistés dans l’URL**, recherche **debounced**, **skeletons** au chargement, **export CSV**, **raccourcis clavier** (`/` focus recherche, `n` nouvelle transaction).
* Alimente directement les métriques **Actual** et **Cleared** des Budgets (J8).

---

## 2) Arborescence & fichiers ajoutés/modifiés

```
src/
├─ types/
│  └─ transactions.ts                  # Types Transaction + DTO
├─ lib/service/
│  └─ transactions.service.ts          # Service API (list/create/update/delete)
├─ hooks/
│  ├─ useTransactions.ts               # Hook session-aware (période, filtres, CRUD, cleared)
│  ├─ useTxUrlState.ts                 # Persistance des filtres dans l'URL
│  └─ useDebouncedValue.ts             # Debounce de la recherche
├─ components/transactions/
│  ├─ TransactionFormDialog.tsx        # Modale créer/éditer (RHF + zod)
│  ├─ TransactionCardItem.tsx          # Item mobile
│  └─ TransactionsSkeleton.tsx         # Skeletons filtres + liste/table
└─ pages/transactions/
   └─ index.tsx                        # Page complète (filtres, totaux, liste, CRUD, CSV, hotkeys)
```

---

## 3) Détails d’implémentation

### 3.1 Types (`src/types/transactions.ts`)

* `Transaction`: `id`, `sessionId`, `bankAccountId`, `memberId?`, `type: "INFLOW"|"OUTFLOW"`, `label`, `amount: string|number` (UI accepte nombre; API attend string `"xx.yy"`), `date: "YYYY-MM-DD"`, `isCleared?`, `notes?`, `category?`, timestamps.
* `CreateTransactionDto` / `UpdateTransactionDto`: conformes API, `amount` **string** côté réseau.
* Expose `DateRange`, `MonthRange` utilitaires.

### 3.2 Service (`useTransactionsService`)

* `listBySession(sessionId, {from,to})` → GET filtré par période.
* `create(dto)` → POST.
* `update(id, dto)` → PATCH (cleared toggle inclus).
* `remove(id)` → DELETE.
  Toutes les mutations déclenchent un **refresh** côté hook.

### 3.3 Hook data (`useTransactions`)

* Déduit la période : `{from,to}` ou `{month}` (mois courant par défaut).
* **Anti double-fetch** avec garde `inFlight`.
* **Filtres client** : `bankAccountId`, `memberId`, `cleared (ALL|CLEARED|UNCLEARED)`, `query`.
* Sortie :

  * `visible` (liste filtrée/triée **date desc**),
  * `totals` (In/Out/Net) des éléments visibles,
  * actions : `createTx`, `updateTx`, `toggleCleared`, `removeTx`, `refresh`.
* Conversion **number → "xx.yy"** pour `amount` gérée automatiquement.

### 3.4 Persistance URL & Debounce

* `useTxUrlState` synchronise état ↔ `?month=&bank=&member=&cleared=&q=` (support Back/Forward).
* `useDebouncedValue` (350 ms) pour la recherche, évite les renders en rafale.

### 3.5 UI /dashboard/transactions

* **Header** : `MonthPicker` + actions (Nouvelle, Rafraîchir, CSV).
* **Filtres** (groupés dans une Card) : Recherche, Compte, Membre, Pointage.
* **Totaux** (3 cards) : Entrées / Sorties / Net, avec `aria-live="polite"`.
* **Liste mobile** : `TransactionCardItem` (date locale, libellés compte & membre, montants colorés, badges catégorie, switch cleared, boutons Éditer/Supprimer).
* **Table desktop** : header **sticky**, montants alignés à droite, noms de compte/membre, badges catégorie, switch cleared, actions avec tooltips.
* **Modale** `TransactionFormDialog` : RHF + zod (`amount` positif, date requise…), champs : type, date, libellé, montant, compte, membre (facultatif), catégorie (OUTFLOW), notes.
* **Export CSV** de la vue courante.
* **Hotkeys** : `/` focus recherche, `n` ouvre la modale de création.
* **Skeletons** : filtres + liste/table quand `loading && (liste vide)`.

### 3.6 i18n

* Clés `nav.transactions`, `tx.*` (actions, filters, totals, table, form, empty, delete, a11y) FR/EN.
* Catégories (FOOD, HOUSING, …) traduites.

### 3.7 Responsive & A11y

* Grilles **mobile-first** (1 col → 2/4 cols selon viewport).
* Table **scrollable** (`overflow-auto`, header sticky).
* `aria-label` sur switches Cleared, `aria-live` sur totaux.
* Focus management correct dans les dialogs.

---

## 4) Scénarios & comportements attendus

1. **Charger** la page avec une session active → liste du **mois courant**.
2. **Créer** une transaction OUT/IN → POST OK → la liste et les totaux se mettent à jour.
3. **Éditer** une transaction → PATCH champs → refresh OK.
4. **Toggle Cleared** → PATCH `isCleared` → l’état visuel change, totaux (si filtrés) aussi.
5. **Supprimer** → modal de confirmation → DELETE → refresh OK.
6. **Filtres** : changer de compte/membre/cleared/recherche → `visible` se met à jour → URL se met à jour.
7. **Navigation Back/Forward** → filtres réappliqués depuis l’URL.
8. **Export CSV** → fichier téléchargé avec les colonnes visibles.

---
## 5) Lien avec étapes suivantes

* **J10 — Dashboard Home** : réutiliser `useTransactions()` pour **dernières transactions**, et `useBanks()`/`useBudgetSummary()` pour KPIs.
* **J11 — Profil** : pas de dépendance directe.
* **J12 — Finitions** : ajout d’**empty states** consolidés, **tests** (J13), **CI/CD** (J14).

---

## 6) Definition of Done (J9)

* [x] Types & service Transactions conformes API.
* [x] Hook session-aware (période mois) + CRUD + cleared toggle.
* [x] Page `/dashboard/transactions` complète (filtres, totaux, liste mobile/table desktop, modale, delete).
* [x] Finitions : URL state, debounced search, skeletons, CSV, hotkeys.
* [x] i18n FR/EN, responsive, a11y.
* [x] Build & lint OK, pas de régression J0–J8.
