### PR TITLE
Release: J6–J9 — Incomes, Expenses, Budgets, Transactions (MVP)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@hookform/resolvers": "^5.2.1",
+        "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-label": "^2.1.7",
         "@radix-ui/react-select": "^2.2.6",
@@ -1148,6 +1149,34 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
       "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
       "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-alert-dialog": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-alert-dialog/-/react-alert-dialog-1.1.15.tgz",
+      "integrity": "sha512-oTVLkEw5GpdRe29BqJ0LSDFWI3qu0vR1M0mUkOQWDIUnY/QIkLpgDMWuKxP94c2NAC2LGcgVhG1ImF3jkZ5wXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dialog": "1.1.15",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@radix-ui/react-arrow": {
       "version": "1.1.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@radix-ui/react-slot": "^1.2.3",
         "@radix-ui/react-switch": "^1.2.6",
         "@radix-ui/react-tabs": "^1.1.13",
+        "@radix-ui/react-tooltip": "^1.2.8",
         "@tailwindcss/vite": "^4.1.12",
         "axios": "^1.11.0",
         "class-variance-authority": "^0.7.1",
@@ -1654,6 +1655,40 @@
         "@radix-ui/react-primitive": "2.1.3",
         "@radix-ui/react-roving-focus": "1.1.11",
         "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.8.tgz",
+      "integrity": "sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-visually-hidden": "1.2.3"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.1",
+    "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-select": "^2.2.6",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-tabs": "^1.1.13",
+    "@radix-ui/react-tooltip": "^1.2.8",
     "@tailwindcss/vite": "^4.1.12",
     "axios": "^1.11.0",
     "class-variance-authority": "^0.7.1",

--- a/src/components/budgets/CompareTile.tsx
+++ b/src/components/budgets/CompareTile.tsx
@@ -1,0 +1,33 @@
+import { Card, CardContent } from "@/components/ui/card";
+
+export default function CompareTile({
+  title,
+  leftLabel,
+  leftValue,
+  rightLabel,
+  rightValue,
+}: {
+  title: string;
+  leftLabel: string;
+  leftValue: string;
+  rightLabel: string;
+  rightValue: string;
+}) {
+  return (
+    <Card>
+      <CardContent className="p-4 sm:p-5">
+        <div className="text-xs uppercase tracking-wide text-muted-foreground">{title}</div>
+        <div className="grid grid-cols-2 gap-3 mt-2">
+          <div>
+            <div className="text-[11px] uppercase tracking-wide text-muted-foreground">{leftLabel}</div>
+            <div className="text-lg font-semibold">{leftValue}</div>
+          </div>
+          <div className="text-right">
+            <div className="text-[11px] uppercase tracking-wide text-muted-foreground">{rightLabel}</div>
+            <div className="text-lg font-semibold">{rightValue}</div>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/budgets/EditNotesDialog.tsx
+++ b/src/components/budgets/EditNotesDialog.tsx
@@ -1,0 +1,48 @@
+import { useForm } from "react-hook-form";
+import { useTranslation } from "react-i18next";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog";
+import { Textarea } from "@/components/ui/textarea";
+import { Button } from "@/components/ui/button";
+
+type Props = {
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+  initial?: string | null;
+  onSave: (notes: string | null) => Promise<void> | void;
+  disabled?: boolean;
+};
+
+export default function EditNotesDialog({ open, onOpenChange, initial, onSave, disabled }: Props) {
+  const { t } = useTranslation();
+  const { register, handleSubmit } = useForm<{ notes: string }>({
+    defaultValues: { notes: initial ?? "" },
+    values: { notes: initial ?? "" },
+  });
+
+  async function onSubmit(v: { notes: string }) {
+    await onSave(v.notes.trim() === "" ? null : v.notes);
+    onOpenChange(false);
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg max-w-[calc(100vw-1.5rem)]">
+        <DialogHeader>
+          <DialogTitle>{t("budgets.notes.title")}</DialogTitle>
+          <DialogDescription>{t("budgets.notes.desc")}</DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-3">
+          <Textarea rows={5} placeholder={t("budgets.notes.placeholder") ?? ""} {...register("notes")} disabled={disabled} />
+          <DialogFooter className="flex flex-col sm:flex-row gap-2">
+            <Button type="button" variant="secondary" className="w-full sm:w-auto" onClick={() => onOpenChange(false)}>
+              {t("common.cancel")}
+            </Button>
+            <Button type="submit" className="w-full sm:w-auto" disabled={disabled}>
+              {t("common.save")}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/budgets/EditOpeningDialog.tsx
+++ b/src/components/budgets/EditOpeningDialog.tsx
@@ -1,33 +1,59 @@
+import { useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useTranslation } from "react-i18next";
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog";
+import {
+  Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter
+} from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 
 const schema = z.object({
-  amount: z.coerce.number().gt(0, "Montant invalide"),
+  amount: z.coerce
+    .number()
+    .refine((n) => Number.isFinite(n), "Montant invalide"), // supprime n >= 0
 });
+
+type FormValues = z.infer<typeof schema>;
 
 type Props = {
   open: boolean;
   onOpenChange: (v: boolean) => void;
-  initial: string; // "123.45"
+  initial: string;                 // "123.45"
   onSave: (amount: number) => Promise<void> | void;
   disabled?: boolean;
 };
 
-export default function EditOpeningDialog({ open, onOpenChange, initial, onSave, disabled }: Props) {
+function toNumber(initial: string) {
+  const n = Number(String(initial ?? "0").replace(",", "."));
+  return Number.isFinite(n) ? n : 0;
+}
+
+export default function EditOpeningDialog({
+  open, onOpenChange, initial, onSave, disabled,
+}: Props) {
   const { t } = useTranslation();
-  const { register, handleSubmit, formState: { errors, isSubmitting } } = useForm<{ amount: number }>({
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+    reset,
+  } = useForm<FormValues>({
     resolver: zodResolver(schema) as any,
-    defaultValues: { amount: Number(String(initial).replace(",", ".")) },
-    values: { amount: Number(String(initial).replace(",", ".")) },
+    defaultValues: { amount: toNumber(initial) },
   });
 
-  async function onSubmit(v: { amount: number }) {
-    await onSave(v.amount);
+  // IMPORTANT : recharger la valeur au moment de l’ouverture (et si initial change)
+  useEffect(() => {
+    if (open) {
+      reset({ amount: toNumber(initial) });
+    }
+  }, [open, initial, reset]);
+
+  async function onSubmit(v: FormValues) {
+    await onSave(v.amount);        // number ✔
     onOpenChange(false);
   }
 
@@ -38,12 +64,22 @@ export default function EditOpeningDialog({ open, onOpenChange, initial, onSave,
           <DialogTitle>{t("budgets.opening.title")}</DialogTitle>
           <DialogDescription>{t("budgets.opening.desc")}</DialogDescription>
         </DialogHeader>
+
         <form onSubmit={handleSubmit(onSubmit)} className="space-y-3">
           <div className="space-y-1">
             <label className="text-sm font-medium">{t("budgets.opening.label")}</label>
-            <Input className="h-9" inputMode="decimal" placeholder="0.00" {...register("amount")} disabled={disabled} />
-            {errors.amount && <p className="text-xs text-destructive">{errors.amount.message as any}</p>}
+            <Input
+              className="h-9"
+              inputMode="decimal"
+              placeholder="0.00"
+              {...register("amount")}
+              disabled={disabled}
+            />
+            {errors.amount && (
+              <p className="text-xs text-destructive">{String(errors.amount.message)}</p>
+            )}
           </div>
+
           <DialogFooter className="flex flex-col sm:flex-row gap-2">
             <Button type="button" variant="secondary" className="w-full sm:w-auto" onClick={() => onOpenChange(false)}>
               {t("common.cancel")}

--- a/src/components/budgets/EditOpeningDialog.tsx
+++ b/src/components/budgets/EditOpeningDialog.tsx
@@ -1,0 +1,59 @@
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useTranslation } from "react-i18next";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+
+const schema = z.object({
+  amount: z.coerce.number().gt(0, "Montant invalide"),
+});
+
+type Props = {
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+  initial: string; // "123.45"
+  onSave: (amount: number) => Promise<void> | void;
+  disabled?: boolean;
+};
+
+export default function EditOpeningDialog({ open, onOpenChange, initial, onSave, disabled }: Props) {
+  const { t } = useTranslation();
+  const { register, handleSubmit, formState: { errors, isSubmitting } } = useForm<{ amount: number }>({
+    resolver: zodResolver(schema) as any,
+    defaultValues: { amount: Number(String(initial).replace(",", ".")) },
+    values: { amount: Number(String(initial).replace(",", ".")) },
+  });
+
+  async function onSubmit(v: { amount: number }) {
+    await onSave(v.amount);
+    onOpenChange(false);
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md max-w-[calc(100vw-1.5rem)]">
+        <DialogHeader>
+          <DialogTitle>{t("budgets.opening.title")}</DialogTitle>
+          <DialogDescription>{t("budgets.opening.desc")}</DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-3">
+          <div className="space-y-1">
+            <label className="text-sm font-medium">{t("budgets.opening.label")}</label>
+            <Input className="h-9" inputMode="decimal" placeholder="0.00" {...register("amount")} disabled={disabled} />
+            {errors.amount && <p className="text-xs text-destructive">{errors.amount.message as any}</p>}
+          </div>
+          <DialogFooter className="flex flex-col sm:flex-row gap-2">
+            <Button type="button" variant="secondary" className="w-full sm:w-auto" onClick={() => onOpenChange(false)}>
+              {t("common.cancel")}
+            </Button>
+            <Button type="submit" className="w-full sm:w-auto" disabled={isSubmitting || disabled}>
+              {t("common.save")}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/budgets/HeroSummary.tsx
+++ b/src/components/budgets/HeroSummary.tsx
@@ -1,0 +1,43 @@
+import { Card, CardContent } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+
+type Row = { label: string; value: string; tone?: "good" | "bad" | "neutral" };
+
+export default function HeroSummary({
+  title,
+  main,
+  rows,
+  tone = "neutral",
+}: {
+  title: string;
+  main: string;
+  rows: Row[];
+  tone?: "good" | "bad" | "neutral";
+}) {
+  const mainTone =
+    tone === "good" ? "text-emerald-600 dark:text-emerald-400"
+    : tone === "bad" ? "text-rose-600 dark:text-rose-400"
+    : "text-foreground";
+  return (
+    <Card>
+      <CardContent className="p-4 sm:p-5">
+        <div className="text-xs uppercase tracking-wide text-muted-foreground">{title}</div>
+        <div className={cn("text-3xl sm:text-4xl font-semibold mt-1", mainTone)}>{main}</div>
+        <div className="mt-3 grid grid-cols-1 sm:grid-cols-2 gap-2">
+          {rows.map((r, i) => {
+            const toneCls = r.tone === "good" ? "text-emerald-600 dark:text-emerald-400"
+              : r.tone === "bad" ? "text-rose-600 dark:text-rose-400"
+              : "text-foreground";
+            return (
+              <div key={i} className="flex items-center justify-between rounded-md border p-2">
+                <span className="text-xs text-muted-foreground">{r.label}</span>
+                <span className={cn("text-sm font-medium", toneCls)}>{r.value}</span>
+              </div>
+            );
+          })}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+

--- a/src/components/budgets/KpiCard.tsx
+++ b/src/components/budgets/KpiCard.tsx
@@ -1,0 +1,29 @@
+import { Card, CardContent } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+
+type Props = {
+  label: string;
+  value: string;
+  hint?: string;
+  tone?: "neutral" | "good" | "bad";
+};
+
+export default function KpiCard({ label, value, hint, tone = "neutral" }: Props) {
+  const toneCls =
+    tone === "good" ? "text-emerald-600 dark:text-emerald-400"
+    : tone === "bad" ? "text-rose-600 dark:text-rose-400"
+    : "text-foreground";
+  const hintCls =
+    tone === "good" ? "text-emerald-600/70 dark:text-emerald-400/80"
+    : tone === "bad" ? "text-rose-600/70 dark:text-rose-400/80"
+    : "text-muted-foreground";
+  return (
+    <Card>
+      <CardContent className="p-4">
+        <div className="text-xs uppercase tracking-wide text-muted-foreground">{label}</div>
+        <div className={cn("text-xl font-semibold mt-1", toneCls)}>{value}</div>
+        {hint ? <div className={cn("text-xs mt-1", hintCls)}>{hint}</div> : null}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/budgets/ModeTabs.tsx
+++ b/src/components/budgets/ModeTabs.tsx
@@ -1,0 +1,18 @@
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+
+type Props = {
+  value: "planned" | "actual" | "cleared";
+  onChange: (v: "planned" | "actual" | "cleared") => void;
+  disabled?: boolean;
+};
+export default function ModeTabs({ value, onChange, disabled }: Props) {
+  return (
+    <Tabs value={value} onValueChange={(v) => onChange(v as any)}>
+      <TabsList className="grid grid-cols-3 w-full sm:w-auto">
+        <TabsTrigger value="planned" disabled={disabled}>Planned</TabsTrigger>
+        <TabsTrigger value="actual" disabled={disabled}>Actual</TabsTrigger>
+        <TabsTrigger value="cleared" disabled={disabled}>Cleared</TabsTrigger>
+      </TabsList>
+    </Tabs>
+  );
+}

--- a/src/components/budgets/MonthPicker.tsx
+++ b/src/components/budgets/MonthPicker.tsx
@@ -1,0 +1,27 @@
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+type Props = {
+  month: string; // "YYYY-MM"
+  onPrev: () => void;
+  onNext: () => void;
+  onChange: (m: string) => void;
+  disabled?: boolean;
+};
+
+export default function MonthPicker({ month, onPrev, onNext, onChange, disabled }: Props) {
+  return (
+    <div className="flex items-center gap-2">
+      <Button variant="outline" size="icon" onClick={onPrev} disabled={disabled}><ChevronLeft className="h-4 w-4" /></Button>
+      <Input
+        type="month"
+        className="h-9 w-[11.5rem]"
+        value={month}
+        onChange={(e) => onChange(e.target.value)}
+        disabled={disabled}
+      />
+      <Button variant="outline" size="icon" onClick={onNext} disabled={disabled}><ChevronRight className="h-4 w-4" /></Button>
+    </div>
+  );
+}

--- a/src/components/expenses/ExpenseCardItem.tsx
+++ b/src/components/expenses/ExpenseCardItem.tsx
@@ -1,0 +1,60 @@
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Pencil, Trash2, ArchiveRestore, Archive } from "lucide-react";
+import type { Expense, BankAccount, Member } from "@/types";
+import { useTranslation } from "react-i18next";
+
+function nfmt(v: string | number | null | undefined, lang: string) {
+  const n = typeof v === "number" ? v : Number(String(v ?? "").replace(",", "."));
+  return Number.isFinite(n)
+    ? new Intl.NumberFormat(lang, { style: "currency", currency: "EUR" }).format(n)
+    : "—";
+}
+
+export default function ExpenseCardItem({
+  expense, bank, member, onEdit, onDelete, onToggleArchive,
+}: {
+  expense: Expense;
+  bank?: BankAccount;
+  member?: Member;
+  onEdit: (e: Expense) => void;
+  onDelete: (e: Expense) => void;
+  onToggleArchive: (e: Expense) => void;
+}) {
+  const { t, i18n } = useTranslation();
+  const amount = nfmt(expense.amount as any, i18n.language);
+
+  return (
+    <Card>
+      <CardContent className="p-3 space-y-2">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <div className="font-medium truncate">{expense.label}</div>
+            <div className="text-sm text-muted-foreground">
+              {t("expenses.fields.day")} {expense.day} · {bank?.label ?? "—"} ·{" "}
+              {member?.name ?? member?.invitedEmail ?? member?.userId ?? "—"}
+            </div>
+            <div className="mt-1">
+              <Badge variant="secondary">{t(`expenses.categories.${expense.category.toLowerCase()}`)}</Badge>
+              {expense.isArchived && <Badge className="ml-2" variant="outline">{t("expenses.badges.archived")}</Badge>}
+            </div>
+          </div>
+          <div className="text-right font-medium">{amount}</div>
+        </div>
+        <div className="flex flex-col xs:flex-row gap-2">
+          <Button variant="outline" size="sm" className="w-full xs:w-auto" onClick={() => onEdit(expense)}>
+            <Pencil className="h-4 w-4 mr-2" /> {t("common.edit")}
+          </Button>
+          <Button variant="secondary" size="sm" className="w-full xs:w-auto" onClick={() => onToggleArchive(expense)}>
+            {expense.isArchived ? <ArchiveRestore className="h-4 w-4 mr-2" /> : <Archive className="h-4 w-4 mr-2" />}
+            {expense.isArchived ? t("expenses.actions.restore") : t("expenses.actions.archive")}
+          </Button>
+          <Button variant="destructive" size="sm" className="w-full xs:w-auto" onClick={() => onDelete(expense)}>
+            <Trash2 className="h-4 w-4 mr-2" /> {t("common.delete")}
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/expenses/ExpenseFormDialog.tsx
+++ b/src/components/expenses/ExpenseFormDialog.tsx
@@ -1,0 +1,220 @@
+import { useEffect } from "react";
+import { useForm, Controller } from "react-hook-form";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
+import {
+  Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select, SelectTrigger, SelectValue, SelectContent, SelectItem,
+} from "@/components/ui/select";
+import type { BankAccount, Member, Expense } from "@/types";
+import { useExpensesService } from "@/lib/service/expense.service";
+
+const CATEGORY_OPTS: Expense["category"][] = [
+  "HOUSING", "UTILITIES", "HEALTH", "FOOD", "TRANSPORT", "SUBSCRIPTIONS", "OTHER",
+];
+
+const schema = z.object({
+  label: z.string().min(1, "Label requis"),
+  amount: z.coerce.number().gt(0, "Montant invalide"),
+  day: z.coerce.number().int().min(1, "Jour invalide").max(31, "Jour invalide"),
+  bankAccountId: z.string().min(1, "Compte requis"),
+  memberId: z.string().min(1, "Membre requis"),
+  category: z.enum(["HOUSING","UTILITIES","HEALTH","FOOD","TRANSPORT","SUBSCRIPTIONS","OTHER"]),
+});
+
+type FormValues = z.infer<typeof schema>;
+
+type Props = {
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+  mode: "create" | "edit";
+  sessionId: string;
+  expense?: Expense | null;
+  bankAccounts: BankAccount[];
+  members: Member[];
+  onSuccess?: () => void;
+};
+
+export default function ExpenseFormDialog({
+  open, onOpenChange, mode, sessionId, expense, bankAccounts, members, onSuccess,
+}: Props) {
+  const { t } = useTranslation();
+  const { create, update } = useExpensesService();
+
+  const {
+      register,
+      control,
+      handleSubmit,
+      formState: { errors, isSubmitting },
+      reset,
+    } = useForm<FormValues>({
+      // ✅ resolver typé explicitement sur FormValues
+      resolver: zodResolver(schema) as any,
+      defaultValues: {
+        label: "",
+        amount: 0,
+        day: 1,
+        bankAccountId: "",
+        memberId: "",
+      },
+    });
+
+  useEffect(() => {
+    if (!open) return;
+    if (mode === "edit" && expense) {
+      const amountNum =
+        typeof (expense as any).amount === "number"
+          ? (expense as any).amount
+          : Number(String((expense as any).amount ?? "").replace(",", "."));
+      reset({
+        label: expense.label,
+        amount: Number.isFinite(amountNum) ? amountNum : 0,
+        day: (expense as any).day,
+        bankAccountId: (expense as any).bankAccountId,
+        memberId: (expense as any).memberId,
+      });
+    } else {
+      reset({
+        label: "",
+        amount: 0,
+        day: 1,
+        bankAccountId: "",
+        memberId: "",
+      });
+    }
+  }, [open, mode, expense, reset]);
+
+  async function onSubmit(v: FormValues) {
+    try {
+      const payload = {
+        label: v.label,
+        amount: String((v.amount as number).toFixed(2)), // API = string
+        day: v.day,
+        bankAccountId: v.bankAccountId,
+        memberId: v.memberId,
+        category: v.category,
+      };
+      if (mode === "create") {
+        await create({ sessionId, ...payload });
+        toast.success(t("expenses.toasts.created"));
+      } else if (expense) {
+        await update(expense.id, payload);
+        toast.success(t("expenses.toasts.updated"));
+      }
+      onOpenChange(false);
+      onSuccess?.();
+    } catch {
+      /* erreurs toast via useApi */
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg max-w-[calc(100vw-1.5rem)]">
+        <DialogHeader>
+          <DialogTitle>{mode === "create" ? t("expenses.form.createTitle") : t("expenses.form.editTitle")}</DialogTitle>
+          <DialogDescription>{mode === "create" ? t("expenses.form.createDesc") : t("expenses.form.editDesc")}</DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+          <div className="space-y-2">
+            <label className="text-sm font-medium">{t("expenses.form.label")}</label>
+            <Input className="h-9" {...register("label")} placeholder={t("expenses.form.labelPh") ?? ""} />
+            {errors.label && <p className="text-xs text-destructive">{errors.label.message as any}</p>}
+          </div>
+
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+            <div className="space-y-2">
+              <label className="text-sm font-medium">{t("expenses.form.amount")}</label>
+              <Input className="h-9" inputMode="decimal" {...register("amount")} placeholder="0.00" />
+              {errors.amount && <p className="text-xs text-destructive">{errors.amount.message as any}</p>}
+            </div>
+            <div className="space-y-2">
+              <label className="text-sm font-medium">{t("expenses.form.day")}</label>
+              <Input className="h-9" inputMode="numeric" {...register("day")} placeholder="1" />
+              {errors.day && <p className="text-xs text-destructive">{errors.day.message as any}</p>}
+            </div>
+            <div className="space-y-2">
+              <label className="text-sm font-medium">{t("expenses.form.category")}</label>
+              <Controller
+                control={control}
+                name="category"
+                render={({ field }) => (
+                  <Select value={field.value} onValueChange={field.onChange}>
+                    <SelectTrigger className="h-9 w-full">
+                      <SelectValue placeholder={t("expenses.form.categoryPh")} />
+                    </SelectTrigger>
+                    <SelectContent className="max-h-[60vh]">
+                      {CATEGORY_OPTS.map((c) => (
+                        <SelectItem key={c} value={c}>{t(`expenses.categories.${c.toLowerCase()}`)}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                )}
+              />
+            </div>
+          </div>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <div className="space-y-2">
+              <label className="text-sm font-medium">{t("expenses.form.bank")}</label>
+              <Controller
+                control={control}
+                name="bankAccountId"
+                render={({ field }) => (
+                  <Select value={field.value} onValueChange={field.onChange}>
+                    <SelectTrigger className="h-9 w-full">
+                      <SelectValue placeholder={t("expenses.form.bankPh")} />
+                    </SelectTrigger>
+                    <SelectContent className="max-h-[60vh]">
+                      {bankAccounts.map((b) => (
+                        <SelectItem key={b.id} value={b.id}>{b.label}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                )}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium">{t("expenses.form.member")}</label>
+              <Controller
+                control={control}
+                name="memberId"
+                render={({ field }) => (
+                  <Select value={field.value} onValueChange={field.onChange}>
+                    <SelectTrigger className="h-9 w-full">
+                      <SelectValue placeholder={t("expenses.form.memberPh")} />
+                    </SelectTrigger>
+                    <SelectContent className="max-h-[60vh]">
+                      {members.map((m) => (
+                        <SelectItem key={m.id} value={m.id}>
+                          {m.name ?? m.invitedEmail ?? m.userId ?? m.id}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                )}
+              />
+            </div>
+          </div>
+
+          <DialogFooter className="flex flex-col sm:flex-row gap-2">
+            <Button type="button" variant="secondary" className="w-full sm:w-auto" onClick={() => onOpenChange(false)}>
+              {t("common.cancel")}
+            </Button>
+            <Button type="submit" className="w-full sm:w-auto" disabled={isSubmitting}>
+              {mode === "create" ? t("common.create") : t("common.save")}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/incomes/IncomeCardItem.tsx
+++ b/src/components/incomes/IncomeCardItem.tsx
@@ -1,0 +1,65 @@
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Pencil, Trash2 } from "lucide-react";
+import type { Income, BankAccount, Member } from "@/types";
+import { useTranslation } from "react-i18next";
+
+function toNumberSafely(v: string | number | null | undefined) {
+  if (typeof v === "number") return v;
+  if (typeof v === "string") {
+    const n = Number(v.replace(",", "."));
+    return Number.isFinite(n) ? n : NaN;
+  }
+  return NaN;
+}
+
+export default function IncomeCardItem({
+  income,
+  bank,
+  member,
+  onEdit,
+  onDelete,
+}: {
+  income: Income;
+  bank?: BankAccount;
+  member?: Member;
+  onEdit: (inc: Income) => void;
+  onDelete: (inc: Income) => void;
+}) {
+  const { i18n, t } = useTranslation();
+
+  const n = toNumberSafely((income as any).amount);
+  const amount = new Intl.NumberFormat(i18n.language, {
+    style: "currency",
+    currency: "EUR",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(Number.isFinite(n) ? n : 0);
+
+  return (
+    <Card>
+      <CardContent className="p-3 space-y-2">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <div className="font-medium truncate">{income.label}</div>
+            <div className="text-sm text-muted-foreground">
+              {t("incomes.fields.day")} {income.day} · {bank?.label ?? "—"} ·{" "}
+              {member?.name ?? member?.invitedEmail ?? member?.userId ?? "—"}
+            </div>
+          </div>
+          <div className="text-right font-medium">{amount}</div>
+        </div>
+        <div className="flex flex-col xs:flex-row gap-2">
+          <Button variant="outline" size="sm" className="w-full xs:w-auto" onClick={() => onEdit(income)}>
+            <Pencil className="h-4 w-4 mr-2" />
+            {t("common.edit")}
+          </Button>
+          <Button variant="destructive" size="sm" className="w-full xs:w-auto" onClick={() => onDelete(income)}>
+            <Trash2 className="h-4 w-4 mr-2" />
+            {t("common.delete")}
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/incomes/IncomeFormDialog.tsx
+++ b/src/components/incomes/IncomeFormDialog.tsx
@@ -1,0 +1,208 @@
+import { useEffect } from "react";
+import { useForm, Controller, type SubmitHandler } from "react-hook-form";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
+import {
+  Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select, SelectTrigger, SelectValue, SelectContent, SelectItem,
+} from "@/components/ui/select";
+import type { BankAccount, Member, Income } from "@/types";
+import { useIncomesService } from "@/lib/service/income.service";
+
+// ✅ schéma strict en number (pas de union string|number)
+const schema = z.object({
+  label: z.string().min(1, "Label requis"),
+  amount: z.coerce.number().gt(0, "Montant invalide"),
+  day: z.coerce.number().int().min(1, "Jour invalide").max(31, "Jour invalide"),
+  bankAccountId: z.string().min(1, "Compte requis"),
+  memberId: z.string().min(1, "Membre requis"),
+});
+type FormValues = z.infer<typeof schema>;
+
+type Props = {
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+  mode: "create" | "edit";
+  sessionId: string;
+  income?: Income | null;
+  bankAccounts: BankAccount[];
+  members: Member[];
+  onSuccess?: () => void;
+};
+
+export default function IncomeFormDialog({
+  open, onOpenChange, mode, sessionId, income, bankAccounts, members, onSuccess,
+}: Props) {
+  const { t } = useTranslation();
+  const { create, update } = useIncomesService();
+
+  const {
+    register,
+    control,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+    reset,
+  } = useForm<FormValues>({
+    // ✅ resolver typé explicitement sur FormValues
+    resolver: zodResolver(schema) as any,
+    defaultValues: {
+      label: "",
+      amount: 0,
+      day: 1,
+      bankAccountId: "",
+      memberId: "",
+    },
+  });
+
+  useEffect(() => {
+    if (!open) return;
+    if (mode === "edit" && income) {
+      const amountNum =
+        typeof (income as any).amount === "number"
+          ? (income as any).amount
+          : Number(String((income as any).amount ?? "").replace(",", "."));
+      reset({
+        label: income.label,
+        amount: Number.isFinite(amountNum) ? amountNum : 0,
+        day: (income as any).day,
+        bankAccountId: (income as any).bankAccountId,
+        memberId: (income as any).memberId,
+      });
+    } else {
+      reset({
+        label: "",
+        amount: 0,
+        day: 1,
+        bankAccountId: "",
+        memberId: "",
+      });
+    }
+  }, [open, mode, income, reset]);
+
+  // ✅ handler typé : SubmitHandler<FormValues>
+  const onSubmitForm: SubmitHandler<FormValues> = async (values) => {
+    try {
+      const payload = {
+        sessionId,
+        label: values.label,
+        amount: String(values.amount.toFixed(2)), // API attend string
+        day: values.day,
+        bankAccountId: values.bankAccountId,
+        memberId: values.memberId,
+      };
+      if (mode === "create") {
+        await create(payload);
+        toast.success(t("incomes.toasts.created"));
+      } else if (income) {
+        await update(income.id, payload);
+        toast.success(t("incomes.toasts.updated"));
+      }
+      onOpenChange(false);
+      onSuccess?.();
+    } catch {
+      /* erreurs toast via useApi */
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg max-w-[calc(100vw-1.5rem)]">
+        <DialogHeader>
+          <DialogTitle>
+            {mode === "create" ? t("incomes.form.createTitle") : t("incomes.form.editTitle")}
+          </DialogTitle>
+          <DialogDescription>
+            {mode === "create" ? t("incomes.form.createDesc") : t("incomes.form.editDesc")}
+          </DialogDescription>
+        </DialogHeader>
+
+        {/* ✅ note: handleSubmit reçoit un SubmitHandler<FormValues> */}
+        <form onSubmit={handleSubmit(onSubmitForm)} className="space-y-4">
+          <div className="space-y-2">
+            <label className="text-sm font-medium">{t("incomes.form.label")}</label>
+            <Input className="h-9" {...register("label")} placeholder={t("incomes.form.labelPh") ?? ""} />
+            {errors.label && <p className="text-xs text-destructive">{errors.label.message as any}</p>}
+          </div>
+
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+            <div className="space-y-2">
+              <label className="text-sm font-medium">{t("incomes.form.amount")}</label>
+              <Input className="h-9" inputMode="decimal" {...register("amount")} placeholder="0.00" />
+              {errors.amount && <p className="text-xs text-destructive">{errors.amount.message as any}</p>}
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium">{t("incomes.form.day")}</label>
+              <Input className="h-9" inputMode="numeric" {...register("day")} placeholder="1" />
+              {errors.day && <p className="text-xs text-destructive">{errors.day.message as any}</p>}
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium">{t("incomes.form.bank")}</label>
+              {/* ✅ Controller pour Select */}
+              <Controller
+                control={control}
+                name="bankAccountId"
+                render={({ field }) => (
+                  <Select value={field.value} onValueChange={field.onChange}>
+                    <SelectTrigger className="h-9 w-full">
+                      <SelectValue placeholder={t("incomes.form.bankPh")} />
+                    </SelectTrigger>
+                    <SelectContent className="max-h-[60vh]">
+                      {bankAccounts.map((b) => (
+                        <SelectItem key={b.id} value={b.id}>
+                          {b.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                )}
+              />
+              {errors.bankAccountId && (
+                <p className="text-xs text-destructive">{errors.bankAccountId.message as any}</p>
+              )}
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <label className="text-sm font-medium">{t("incomes.form.member")}</label>
+            <Controller
+              control={control}
+              name="memberId"
+              render={({ field }) => (
+                <Select value={field.value} onValueChange={field.onChange}>
+                  <SelectTrigger className="h-9 w-full">
+                    <SelectValue placeholder={t("incomes.form.memberPh")} />
+                  </SelectTrigger>
+                  <SelectContent className="max-h-[60vh]">
+                    {members.map((m) => (
+                      <SelectItem key={m.id} value={m.id}>
+                        {m.name ?? m.invitedEmail ?? m.userId ?? m.id}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              )}
+            />
+            {errors.memberId && <p className="text-xs text-destructive">{errors.memberId.message as any}</p>}
+          </div>
+
+          <DialogFooter className="flex flex-col sm:flex-row gap-2">
+            <Button type="button" variant="secondary" className="w-full sm:w-auto" onClick={() => onOpenChange(false)}>
+              {t("common.cancel")}
+            </Button>
+            <Button type="submit" className="w-full sm:w-auto" disabled={isSubmitting}>
+              {mode === "create" ? t("common.create") : t("common.save")}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/transactions/TransactionCardItem.tsx
+++ b/src/components/transactions/TransactionCardItem.tsx
@@ -38,7 +38,7 @@ export default function TransactionCardItem({ tx, onEdit, onDelete, onToggleClea
             {tx.isCleared && <Badge variant="secondary">Cleared</Badge>}
           </div>
           <div className="flex items-center gap-2">
-            <Switch checked={!!tx.isCleared} onCheckedChange={() => onToggleCleared(tx)} />
+            <Switch aria-label={`Toggle cleared: ${tx.label}`} checked={!!tx.isCleared} onCheckedChange={() => onToggleCleared(tx)} />
             <Button size="icon" variant="outline" onClick={() => onEdit(tx)}><Pencil className="h-4 w-4" /></Button>
             <Button size="icon" variant="destructive" onClick={() => onDelete(tx)}><Trash2 className="h-4 w-4" /></Button>
           </div>

--- a/src/components/transactions/TransactionCardItem.tsx
+++ b/src/components/transactions/TransactionCardItem.tsx
@@ -1,0 +1,49 @@
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
+import { Pencil, Trash2 } from "lucide-react";
+import type { Transaction } from "@/types";
+
+type Props = {
+  tx: Transaction;
+  onEdit: (tx: Transaction) => void;
+  onDelete: (tx: Transaction) => void;
+  onToggleCleared: (tx: Transaction) => void;
+  fmt: (n: number | string) => string;
+};
+
+export default function TransactionCardItem({ tx, onEdit, onDelete, onToggleCleared, fmt }: Props) {
+  const isOut = tx.type === "OUTFLOW";
+  const tone = isOut ? "text-rose-600 dark:text-rose-400" : "text-emerald-600 dark:text-emerald-400";
+  return (
+    <Card>
+      <CardContent className="p-4 space-y-2">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <div className="text-sm font-medium truncate">{tx.label}</div>
+            <div className="text-xs text-muted-foreground">{tx.date}</div>
+            <div className="mt-1 text-xs text-muted-foreground truncate">
+              {tx.bankAccountId}{tx.memberId ? ` • ${tx.memberId}` : ""}
+            </div>
+          </div>
+          <div className={`text-base font-semibold whitespace-nowrap ${tone}`}>
+            {fmt(tx.amount)}
+          </div>
+        </div>
+
+        <div className="flex items-center justify-between gap-2">
+          <div className="flex items-center gap-2">
+            {tx.category && <Badge variant="outline">{tx.category}</Badge>}
+            {tx.isCleared && <Badge variant="secondary">Cleared</Badge>}
+          </div>
+          <div className="flex items-center gap-2">
+            <Switch checked={!!tx.isCleared} onCheckedChange={() => onToggleCleared(tx)} />
+            <Button size="icon" variant="outline" onClick={() => onEdit(tx)}><Pencil className="h-4 w-4" /></Button>
+            <Button size="icon" variant="destructive" onClick={() => onDelete(tx)}><Trash2 className="h-4 w-4" /></Button>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/transactions/TransactionCardItem.tsx
+++ b/src/components/transactions/TransactionCardItem.tsx
@@ -11,21 +11,39 @@ type Props = {
   onDelete: (tx: Transaction) => void;
   onToggleCleared: (tx: Transaction) => void;
   fmt: (n: number | string) => string;
+  bankLabel?: string;
+  memberLabel?: string;
+  dateLabel?: string;
 };
 
-export default function TransactionCardItem({ tx, onEdit, onDelete, onToggleCleared, fmt }: Props) {
+export default function TransactionCardItem({
+  tx, onEdit, onDelete, onToggleCleared, fmt,
+  bankLabel, memberLabel, dateLabel
+}: Props) {
   const isOut = tx.type === "OUTFLOW";
   const tone = isOut ? "text-rose-600 dark:text-rose-400" : "text-emerald-600 dark:text-emerald-400";
+
   return (
     <Card>
       <CardContent className="p-4 space-y-2">
         <div className="flex items-start justify-between gap-3">
           <div className="min-w-0">
             <div className="text-sm font-medium truncate">{tx.label}</div>
-            <div className="text-xs text-muted-foreground">{tx.date}</div>
-            <div className="mt-1 text-xs text-muted-foreground truncate">
-              {tx.bankAccountId}{tx.memberId ? ` • ${tx.memberId}` : ""}
+
+            {/* ⬇️ Remplacement DU BLOC META ICI */}
+            <div className="text-xs text-muted-foreground">
+              {dateLabel ?? tx.date}
             </div>
+            <div className="mt-1 text-xs text-muted-foreground truncate">
+              {bankLabel ?? tx.bankAccountId}
+              {memberLabel
+                ? ` • ${memberLabel}`
+                : tx.memberId
+                ? ` • ${tx.memberId}`
+                : ""}
+            </div>
+            {/* ⬆️ Fin remplacement */}
+
           </div>
           <div className={`text-base font-semibold whitespace-nowrap ${tone}`}>
             {fmt(tx.amount)}
@@ -34,11 +52,15 @@ export default function TransactionCardItem({ tx, onEdit, onDelete, onToggleClea
 
         <div className="flex items-center justify-between gap-2">
           <div className="flex items-center gap-2">
-            {tx.category && <Badge variant="outline">{tx.category}</Badge>}
+            {(tx as any).category && <Badge variant="outline">{(tx as any).category}</Badge>}
             {tx.isCleared && <Badge variant="secondary">Cleared</Badge>}
           </div>
           <div className="flex items-center gap-2">
-            <Switch aria-label={`Toggle cleared: ${tx.label}`} checked={!!tx.isCleared} onCheckedChange={() => onToggleCleared(tx)} />
+            <Switch
+              aria-label={`Toggle cleared: ${tx.label}`}
+              checked={!!tx.isCleared}
+              onCheckedChange={() => onToggleCleared(tx)}
+            />
             <Button size="icon" variant="outline" onClick={() => onEdit(tx)}><Pencil className="h-4 w-4" /></Button>
             <Button size="icon" variant="destructive" onClick={() => onDelete(tx)}><Trash2 className="h-4 w-4" /></Button>
           </div>

--- a/src/components/transactions/TransactionFormDialog.tsx
+++ b/src/components/transactions/TransactionFormDialog.tsx
@@ -1,0 +1,235 @@
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useTranslation } from "react-i18next";
+import {
+  Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import type { Transaction, TransactionCategory, TransactionType } from "@/types";
+
+const schema = z.object({
+  type: z.enum(["INFLOW", "OUTFLOW"] as const),
+  date: z.string().min(10, "Date invalide"),
+  label: z.string().trim().min(1, "Libellé requis"),
+  amount: z.coerce.number().positive("Montant > 0"),
+  bankAccountId: z.string().min(1, "Compte requis"),
+  memberId: z.string().optional().or(z.literal("")),
+  notes: z.string().optional().nullable(),
+  category: z.string().optional().nullable(),
+});
+type FormValues = z.infer<typeof schema>;
+type Option = { id: string; label: string };
+
+type Props = {
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+  mode: "create" | "edit";
+  initial?: Partial<Transaction> | null;
+  bankOptions: Option[];
+  memberOptions?: Option[];
+  onSubmit: (values: Omit<FormValues, "memberId" | "category" | "notes"> & {
+    memberId?: string | null;
+    category?: TransactionCategory | null;
+    notes?: string | null;
+  }) => Promise<void> | void;
+  disabled?: boolean;
+};
+
+// sentinelles
+const NONE = "__NONE__";
+const NO_BANK = "__NO_BANK__";
+
+export default function TransactionFormDialog({
+  open, onOpenChange, mode, initial, bankOptions, memberOptions = [], onSubmit, disabled
+}: Props) {
+  const { t } = useTranslation();
+
+  const safeBanks = (bankOptions ?? []).filter(o => o.id && o.id.trim() !== "");
+  const firstBank = safeBanks[0]?.id ?? NO_BANK;
+
+const {
+  register, handleSubmit, reset, setValue, watch,
+  formState: { errors, isSubmitting }
+} = useForm<FormValues>({
+  resolver: zodResolver(schema) as any,
+  defaultValues: {
+    type: (initial?.type as TransactionType) ?? "OUTFLOW",
+    date: initial?.date ?? new Date().toISOString().slice(0, 10),
+    label: initial?.label ?? "",
+    amount: typeof initial?.amount === "number"
+      ? initial?.amount
+      : Number(String(initial?.amount ?? "0").replace(",", ".")),
+    bankAccountId: initial?.bankAccountId ?? firstBank,
+    memberId: initial?.memberId ?? "",
+    notes: initial?.notes ?? "",
+    category: (initial as any)?.category ?? "",
+  },
+});
+
+  // Re-populate à l’ouverture (ou changement initial)
+useEffect(() => {
+  if (!open) return;
+  reset({
+    type: (initial?.type as TransactionType) ?? "OUTFLOW",
+    date: initial?.date ?? new Date().toISOString().slice(0, 10),
+    label: initial?.label ?? "",
+    amount: typeof initial?.amount === "number"
+      ? initial?.amount
+      : Number(String(initial?.amount ?? "0").replace(",", ".")),
+    bankAccountId: initial?.bankAccountId ?? firstBank,
+    memberId: initial?.memberId ?? "",
+    notes: initial?.notes ?? "",
+    category: (initial as any)?.category ?? "",
+  });
+}, [open, initial?.id]);
+
+  const type = watch("type");
+
+  async function onSubmitInternal(v: FormValues) {
+    await onSubmit({
+      ...v,
+      memberId: v.memberId ? v.memberId : undefined,
+      category: (v.category as TransactionCategory) || undefined,
+      notes: v.notes ?? undefined,
+    });
+    onOpenChange(false);
+  }
+
+  const bankVal = watch("bankAccountId") || firstBank;
+  const memberVal = (watch("memberId") || "") as string;
+  const categoryVal = (watch("category") || "") as string;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg max-w-[calc(100vw-1.5rem)]">
+        <DialogHeader>
+          <DialogTitle>
+            {mode === "create" ? t("tx.form.titleCreate") : t("tx.form.titleEdit")}
+          </DialogTitle>
+          <DialogDescription>{t("tx.form.description")}</DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit(onSubmitInternal)} className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          {/* Type */}
+          <div className="space-y-1">
+            <Label>{t("tx.form.type")}</Label>
+            <Select
+              value={watch("type")}
+              onValueChange={(val) => setValue("type", val as any)}
+              disabled={disabled}
+            >
+              <SelectTrigger><SelectValue placeholder="Type" /></SelectTrigger>
+              <SelectContent>
+                <SelectItem value="INFLOW">{t("tx.types.inflow")}</SelectItem>
+                <SelectItem value="OUTFLOW">{t("tx.types.outflow")}</SelectItem>
+              </SelectContent>
+            </Select>
+            {errors.type && <p className="text-xs text-destructive">{String(errors.type.message)}</p>}
+          </div>
+
+          {/* Date */}
+          <div className="space-y-1">
+            <Label>{t("tx.form.date")}</Label>
+            <Input type="date" className="h-9" disabled={disabled} {...register("date")} />
+            {errors.date && <p className="text-xs text-destructive">{String(errors.date.message)}</p>}
+          </div>
+
+          {/* Libellé */}
+          <div className="space-y-1 sm:col-span-2">
+            <Label>{t("tx.form.label")}</Label>
+            <Input className="h-9" placeholder={t("tx.form.labelPh") ?? ""} disabled={disabled} {...register("label")} />
+            {errors.label && <p className="text-xs text-destructive">{String(errors.label.message)}</p>}
+          </div>
+
+          {/* Montant */}
+          <div className="space-y-1">
+            <Label>{t("tx.form.amount")}</Label>
+            <Input className="h-9" inputMode="decimal" placeholder="0.00" disabled={disabled} {...register("amount")} />
+            {errors.amount && <p className="text-xs text-destructive">{String(errors.amount.message)}</p>}
+          </div>
+
+          {/* Compte bancaire (aucune valeur vide; fallback NO_BANK désactivé) */}
+          <div className="space-y-1">
+            <Label>{t("tx.form.bank")}</Label>
+            <Select
+              value={bankVal}
+              onValueChange={(val) => setValue("bankAccountId", val)}
+              disabled={disabled || safeBanks.length === 0}
+            >
+              <SelectTrigger><SelectValue placeholder={t("tx.form.bankPh") ?? ""} /></SelectTrigger>
+              <SelectContent>
+                {safeBanks.length === 0 ? (
+                  <SelectItem value={NO_BANK} disabled>{t("tx.form.bankPh") ?? "Aucun compte disponible"}</SelectItem>
+                ) : (
+                  safeBanks.map((o) => <SelectItem key={o.id} value={o.id}>{o.label}</SelectItem>)
+                )}
+              </SelectContent>
+            </Select>
+            {errors.bankAccountId && <p className="text-xs text-destructive">{String(errors.bankAccountId.message)}</p>}
+          </div>
+
+          {/* Membre (sentinelle NONE) */}
+          <div className="space-y-1">
+            <Label>{t("tx.form.member")}</Label>
+            <Select
+              value={memberVal || NONE}
+              onValueChange={(val) => setValue("memberId", val === NONE ? "" : val)}
+              disabled={disabled || (memberOptions ?? []).length === 0}
+            >
+              <SelectTrigger><SelectValue placeholder={t("tx.form.memberPh") ?? ""} /></SelectTrigger>
+              <SelectContent>
+                <SelectItem value={NONE}>{t("tx.form.memberNone")}</SelectItem>
+                {(memberOptions ?? []).filter(o => o.id && o.id.trim() !== "").map((o) => (
+                  <SelectItem key={o.id} value={o.id}>{o.label}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* Catégorie (sentinelle NONE, activée si OUTFLOW) */}
+          <div className="space-y-1">
+            <Label>{t("tx.form.category")}</Label>
+            <Select
+              value={categoryVal || NONE}
+              onValueChange={(val) => setValue("category", val === NONE ? "" : val)}
+              disabled={disabled || type !== "OUTFLOW"}
+            >
+              <SelectTrigger><SelectValue placeholder={t("tx.form.categoryPh") ?? ""} /></SelectTrigger>
+              <SelectContent>
+                <SelectItem value={NONE}>{t("tx.form.categoryNone")}</SelectItem>
+                <SelectItem value="FOOD">{t("categories.FOOD")}</SelectItem>
+                <SelectItem value="HOUSING">{t("categories.HOUSING")}</SelectItem>
+                <SelectItem value="UTILITIES">{t("categories.UTILITIES")}</SelectItem>
+                <SelectItem value="HEALTH">{t("categories.HEALTH")}</SelectItem>
+                <SelectItem value="TRANSPORT">{t("categories.TRANSPORT")}</SelectItem>
+                <SelectItem value="SUBSCRIPTIONS">{t("categories.SUBSCRIPTIONS")}</SelectItem>
+                <SelectItem value="OTHER">{t("categories.OTHER")}</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* Notes */}
+          <div className="space-y-1 sm:col-span-2">
+            <Label>{t("tx.form.notes")}</Label>
+            <Textarea rows={3} disabled={disabled} {...register("notes")} />
+          </div>
+
+          <DialogFooter className="sm:col-span-2 flex flex-col sm:flex-row gap-2">
+            <Button type="button" variant="secondary" className="w-full sm:w-auto" onClick={() => onOpenChange(false)}>
+              {t("common.cancel")}
+            </Button>
+            <Button type="submit" className="w-full sm:w-auto" disabled={isSubmitting || disabled}>
+              {mode === "create" ? t("common.create") : t("common.save")}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/transactions/TransactionsSkeleton.tsx
+++ b/src/components/transactions/TransactionsSkeleton.tsx
@@ -1,0 +1,46 @@
+// src/components/transactions/TransactionsSkeleton.tsx
+import { Card, CardContent } from "@/components/ui/card";
+
+export function FiltersSkeleton() {
+  return (
+    <Card>
+      <CardContent className="p-4 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="space-y-2">
+            <div className="h-3 w-20 bg-muted rounded" />
+            <div className="h-9 w-full bg-muted rounded" />
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}
+
+export function ListSkeleton() {
+  return (
+    <div className="space-y-3">
+      {Array.from({ length: 6 }).map((_, i) => (
+        <Card key={i}>
+          <CardContent className="p-4 space-y-2">
+            <div className="flex items-center justify-between">
+              <div className="h-4 w-40 bg-muted rounded" />
+              <div className="h-5 w-24 bg-muted rounded" />
+            </div>
+            <div className="h-3 w-28 bg-muted rounded" />
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}
+
+export function TableSkeleton() {
+  return (
+    <div className="hidden sm:block">
+      <div className="h-7 w-full bg-muted rounded mb-2" />
+      {Array.from({ length: 8 }).map((_, i) => (
+        <div key={i} className="h-10 w-full bg-muted/70 rounded mb-2" />
+      ))}
+    </div>
+  );
+}

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,155 @@
+import * as React from "react"
+import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
+
+import { cn } from "@/lib/utils"
+import { buttonVariants } from "@/components/ui/button"
+
+function AlertDialog({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />
+}
+
+function AlertDialogTrigger({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Trigger>) {
+  return (
+    <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />
+  )
+}
+
+function AlertDialogPortal({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
+  return (
+    <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />
+  )
+}
+
+function AlertDialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Overlay>) {
+  return (
+    <AlertDialogPrimitive.Overlay
+      data-slot="alert-dialog-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Content>) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Content
+        data-slot="alert-dialog-content"
+        className={cn(
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+          className
+        )}
+        {...props}
+      />
+    </AlertDialogPortal>
+  )
+}
+
+function AlertDialogHeader({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-header"
+      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogFooter({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+  return (
+    <AlertDialogPrimitive.Title
+      data-slot="alert-dialog-title"
+      className={cn("text-lg font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+  return (
+    <AlertDialogPrimitive.Description
+      data-slot="alert-dialog-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogAction({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Action>) {
+  return (
+    <AlertDialogPrimitive.Action
+      className={cn(buttonVariants(), className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogCancel({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Cancel>) {
+  return (
+    <AlertDialogPrimitive.Cancel
+      className={cn(buttonVariants({ variant: "outline" }), className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  AlertDialog,
+  AlertDialogPortal,
+  AlertDialogOverlay,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+}

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,0 +1,18 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        "border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Textarea }

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -1,0 +1,59 @@
+import * as React from "react"
+import * as TooltipPrimitive from "@radix-ui/react-tooltip"
+
+import { cn } from "@/lib/utils"
+
+function TooltipProvider({
+  delayDuration = 0,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
+  return (
+    <TooltipPrimitive.Provider
+      data-slot="tooltip-provider"
+      delayDuration={delayDuration}
+      {...props}
+    />
+  )
+}
+
+function Tooltip({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Root>) {
+  return (
+    <TooltipProvider>
+      <TooltipPrimitive.Root data-slot="tooltip" {...props} />
+    </TooltipProvider>
+  )
+}
+
+function TooltipTrigger({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />
+}
+
+function TooltipContent({
+  className,
+  sideOffset = 0,
+  children,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Content>) {
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Content
+        data-slot="tooltip-content"
+        sideOffset={sideOffset}
+        className={cn(
+          "bg-primary text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        <TooltipPrimitive.Arrow className="bg-primary fill-primary z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
+      </TooltipPrimitive.Content>
+    </TooltipPrimitive.Portal>
+  )
+}
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }

--- a/src/hooks/useBudgetSummary.ts
+++ b/src/hooks/useBudgetSummary.ts
@@ -3,32 +3,33 @@ import { useSessionStore } from "@/stores/sessionStore";
 import { useBudgetsService } from "@/lib/service/budget.service";
 import type { Budget, BudgetSummary, MonthString } from "@/types";
 
-// util interne
-function toMonthString(d = new Date()): MonthString {
+function toMonthString(d: Date = new Date()): MonthString {
   const y = d.getFullYear();
   const m = String(d.getMonth() + 1).padStart(2, "0");
-  return `${y}-${m}` as MonthString;
+  return `${y}-${m}`;
 }
 function toMoneyString(v: number | string) {
   const n = typeof v === "number" ? v : Number(String(v).replace(",", "."));
   const safe = Number.isFinite(n) ? n : 0;
   return safe.toFixed(2);
 }
-const num = (s: string | number | null | undefined) =>
+const toNum = (s: string | number | null | undefined) =>
   Number(String(s ?? "0").replace(",", "."));
 
 export function useBudgetSummary(initialMonth?: MonthString) {
   const { currentSessionId } = useSessionStore();
   const svc = useBudgetsService();
 
-  // stabiliser les méthodes
+  // Stabilisation des méthodes (StrictMode-safe)
   const getSummaryRef = useRef(svc.getSummary);
   const getByMonthRef = useRef(svc.getByMonth);
   const updateRef = useRef(svc.update);
+  const createRef = useRef(svc.create);
   useEffect(() => {
     getSummaryRef.current = svc.getSummary;
     getByMonthRef.current = svc.getByMonth;
     updateRef.current = svc.update;
+    createRef.current = svc.create;
   }, [svc]);
 
   const [month, setMonth] = useState<MonthString>(initialMonth ?? toMonthString());
@@ -36,6 +37,7 @@ export function useBudgetSummary(initialMonth?: MonthString) {
   const [loading, setLoading] = useState(false);
   const inFlight = useRef(false);
 
+  // Charge le résumé avec fallback auto (createIfMissing=true)
   const refresh = useCallback(async () => {
     if (!currentSessionId || !month) return;
     if (inFlight.current) return;
@@ -54,7 +56,7 @@ export function useBudgetSummary(initialMonth?: MonthString) {
     void refresh();
   }, [refresh]);
 
-  // navigation mois
+  // Navigation mois
   const goPrevMonth = useCallback(() => {
     const [y, m] = month.split("-").map(Number);
     const d = new Date(y, m - 2, 1);
@@ -67,95 +69,152 @@ export function useBudgetSummary(initialMonth?: MonthString) {
     setMonth(toMonthString(d));
   }, [month]);
 
-  // assure un budgetId (ton summary utilise désormais "budget")
-  const ensureBudgetId = useCallback(async (): Promise<string | null> => {
-    if (!currentSessionId) return null;
-    if (summary?.budget) return summary.budget; // <-- changement ici
-    try {
-      const b = await getByMonthRef.current(currentSessionId, month);
-      return (b as Budget)?.id ?? null;
-    } catch {
-      return null;
-    }
-  }, [currentSessionId, month, summary?.budget]);
+  // Assure un budget existant, sinon le crée. Met à jour summary.budget avec l'objet Budget.
+  const ensureBudgetIdOrCreate = useCallback(
+    async (opts?: { opening?: number | string; notes?: string | null }): Promise<string | null> => {
+      if (!currentSessionId) return null;
 
-  // actions
+      // 1) Déjà présent dans le summary (objet Budget) ?
+      if (summary?.budget?.id) return summary.budget.id;
+
+      // 2) Essaye de récupérer le budget par mois (si créé ailleurs)
+      try {
+        const b = await getByMonthRef.current(currentSessionId, month);
+        if (b?.id) {
+          setSummary(prev => (prev ? { ...prev, budget: b } : prev));
+          return b.id;
+        }
+      } catch {
+        // 404 attendu si inexistant
+      }
+
+      // 3) Crée un budget si absent
+      try {
+        const opening = toMoneyString(opts?.opening ?? summary?.openingBalance ?? "0");
+        const created = await createRef.current({
+          sessionId: currentSessionId,
+          month,
+          openingBalance: opening,
+          notes: opts?.notes ?? summary?.budget?.notes ?? null,
+        });
+        if (created?.id) {
+          setSummary(prev => (prev ? { ...prev, budget: created } : prev));
+          return created.id;
+        }
+        return null;
+      } catch {
+        return null;
+      }
+    },
+    [currentSessionId, month, summary]
+  );
+
+  // Expose aussi l'objet Budget (sans 404) pour l'UI
+  const getOrCreateBudget = useCallback(async (): Promise<Budget | null> => {
+    // Si le summary embarque déjà le budget complet, retourne-le
+    if (summary?.budget?.id) return summary.budget;
+
+    // Sinon, tente lecture ; si ok, synchronise et renvoie
+    if (currentSessionId) {
+      try {
+        const b = await getByMonthRef.current(currentSessionId, month);
+        if (b?.id) {
+          setSummary(prev => (prev ? { ...prev, budget: b } : prev));
+          return b;
+        }
+      } catch {
+        // ignore
+      }
+    }
+
+    // Sinon, crée et renvoie un objet minimal si l'API n'est pas encore consistante
+    const id = await ensureBudgetIdOrCreate();
+    if (!id || !currentSessionId) return null;
+    return (
+      summary?.budget ?? {
+        id,
+        sessionId: currentSessionId,
+        month,
+        openingBalance: summary?.openingBalance ?? "0.00",
+        notes: null,
+        locked: false,
+      }
+    );
+  }, [summary, currentSessionId, month, ensureBudgetIdOrCreate]);
+
+  // Actions
   const lock = useCallback(async () => {
-    const id = await ensureBudgetId();
+    const id = await ensureBudgetIdOrCreate();
     if (!id) return;
     await updateRef.current(id, { locked: true });
     await refresh();
-  }, [ensureBudgetId, refresh]);
+  }, [ensureBudgetIdOrCreate, refresh]);
 
   const unlock = useCallback(async () => {
-    const id = await ensureBudgetId();
+    const id = await ensureBudgetIdOrCreate();
     if (!id) return;
     await updateRef.current(id, { locked: false });
     await refresh();
-  }, [ensureBudgetId, refresh]);
+  }, [ensureBudgetIdOrCreate, refresh]);
 
-  const updateOpening = useCallback(async (amount: number | string) => {
-    const id = await ensureBudgetId();
-    if (!id) return;
-    await updateRef.current(id, { openingBalance: toMoneyString(amount) });
-    await refresh();
-  }, [ensureBudgetId, refresh]);
+  const updateOpening = useCallback(
+    async (amount: number | string) => {
+      const id = await ensureBudgetIdOrCreate({ opening: amount });
+      if (!id) return;
+      await updateRef.current(id, { openingBalance: toMoneyString(amount) });
+      await refresh();
+    },
+    [ensureBudgetIdOrCreate, refresh]
+  );
 
-  const updateNotes = useCallback(async (notes: string | null) => {
-    const id = await ensureBudgetId();
-    if (!id) return;
-    await updateRef.current(id, { notes: notes ?? null });
-    await refresh();
-  }, [ensureBudgetId, refresh]);
+  const updateNotes = useCallback(
+    async (notes: string | null) => {
+      const id = await ensureBudgetIdOrCreate({ notes });
+      if (!id) return;
+      await updateRef.current(id, { notes: notes ?? null });
+      await refresh();
+    },
+    [ensureBudgetIdOrCreate, refresh]
+  );
 
-  // KPIs dérivés (plats selon ton typage)
+  // KPIs numériques (champs plats du summary)
   const kpis = useMemo(() => {
     if (!summary) return null;
-    const opening = num(summary.openingBalance);
-
-    const plannedIn = num(summary.plannedIncome);
-    const plannedOut = num(summary.plannedExpense);
-    const netPlanned = num(summary.netPlanned);
-    const projectedEndBalance = num(summary.projectedEndBalance);
-
-    const actualIn = num(summary.actualInFlow);
-    const actualOut = num(summary.actualOutFlow);
-    const netActual = num(summary.netActual);
-    const endingBalance = num(summary.endingBalance);
-
-    const clearedIn = num(summary.clearedInFlow);
-    const clearedOut = num(summary.clearedOutFlow);
-    const netCleared = num(summary.netCleared);
-    const clearedEndingBalance = num(summary.clearedEndingBalance);
-
     return {
-      opening,
-      plannedIn,
-      plannedOut,
-      netPlanned,
-      projectedEndBalance,
-      actualIn,
-      actualOut,
-      netActual,
-      endingBalance,
-      clearedIn,
-      clearedOut,
-      netCleared,
-      clearedEndingBalance,
+      opening: toNum(summary.openingBalance),
+      plannedIn: toNum(summary.plannedIncome),
+      plannedOut: toNum(summary.plannedExpense),
+      netPlanned: toNum(summary.netPlanned),
+      projectedEndBalance: toNum(summary.projectedEndBalance),
+      actualIn: toNum(summary.actualInFlow),
+      actualOut: toNum(summary.actualOutFlow),
+      netActual: toNum(summary.netActual),
+      endingBalance: toNum(summary.endingBalance),
+      clearedIn: toNum(summary.clearedInFlow),
+      clearedOut: toNum(summary.clearedOutFlow),
+      netCleared: toNum(summary.netCleared),
+      clearedEndingBalance: toNum(summary.clearedEndingBalance),
     };
   }, [summary]);
 
   return {
     // état
     month,
-    setMonth, goPrevMonth, goNextMonth,
+    setMonth,
+    goPrevMonth,
+    goNextMonth,
     summary,
     loading,
     kpis,
 
     // actions
     refresh,
-    lock, unlock,
-    updateOpening, updateNotes,
+    lock,
+    unlock,
+    updateOpening,
+    updateNotes,
+
+    // helper pour l'UI
+    getOrCreateBudget,
   };
 }

--- a/src/hooks/useBudgetSummary.ts
+++ b/src/hooks/useBudgetSummary.ts
@@ -1,0 +1,161 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useSessionStore } from "@/stores/sessionStore";
+import { useBudgetsService } from "@/lib/service/budget.service";
+import type { Budget, BudgetSummary, MonthString } from "@/types";
+
+// util interne
+function toMonthString(d = new Date()): MonthString {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  return `${y}-${m}` as MonthString;
+}
+function toMoneyString(v: number | string) {
+  const n = typeof v === "number" ? v : Number(String(v).replace(",", "."));
+  const safe = Number.isFinite(n) ? n : 0;
+  return safe.toFixed(2);
+}
+const num = (s: string | number | null | undefined) =>
+  Number(String(s ?? "0").replace(",", "."));
+
+export function useBudgetSummary(initialMonth?: MonthString) {
+  const { currentSessionId } = useSessionStore();
+  const svc = useBudgetsService();
+
+  // stabiliser les méthodes
+  const getSummaryRef = useRef(svc.getSummary);
+  const getByMonthRef = useRef(svc.getByMonth);
+  const updateRef = useRef(svc.update);
+  useEffect(() => {
+    getSummaryRef.current = svc.getSummary;
+    getByMonthRef.current = svc.getByMonth;
+    updateRef.current = svc.update;
+  }, [svc]);
+
+  const [month, setMonth] = useState<MonthString>(initialMonth ?? toMonthString());
+  const [summary, setSummary] = useState<BudgetSummary | null>(null);
+  const [loading, setLoading] = useState(false);
+  const inFlight = useRef(false);
+
+  const refresh = useCallback(async () => {
+    if (!currentSessionId || !month) return;
+    if (inFlight.current) return;
+    inFlight.current = true;
+    setLoading(true);
+    try {
+      const s = await getSummaryRef.current(currentSessionId, month, { createIfMissing: true });
+      setSummary(s);
+    } finally {
+      setLoading(false);
+      inFlight.current = false;
+    }
+  }, [currentSessionId, month]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  // navigation mois
+  const goPrevMonth = useCallback(() => {
+    const [y, m] = month.split("-").map(Number);
+    const d = new Date(y, m - 2, 1);
+    setMonth(toMonthString(d));
+  }, [month]);
+
+  const goNextMonth = useCallback(() => {
+    const [y, m] = month.split("-").map(Number);
+    const d = new Date(y, m, 1);
+    setMonth(toMonthString(d));
+  }, [month]);
+
+  // assure un budgetId (ton summary utilise désormais "budget")
+  const ensureBudgetId = useCallback(async (): Promise<string | null> => {
+    if (!currentSessionId) return null;
+    if (summary?.budget) return summary.budget; // <-- changement ici
+    try {
+      const b = await getByMonthRef.current(currentSessionId, month);
+      return (b as Budget)?.id ?? null;
+    } catch {
+      return null;
+    }
+  }, [currentSessionId, month, summary?.budget]);
+
+  // actions
+  const lock = useCallback(async () => {
+    const id = await ensureBudgetId();
+    if (!id) return;
+    await updateRef.current(id, { locked: true });
+    await refresh();
+  }, [ensureBudgetId, refresh]);
+
+  const unlock = useCallback(async () => {
+    const id = await ensureBudgetId();
+    if (!id) return;
+    await updateRef.current(id, { locked: false });
+    await refresh();
+  }, [ensureBudgetId, refresh]);
+
+  const updateOpening = useCallback(async (amount: number | string) => {
+    const id = await ensureBudgetId();
+    if (!id) return;
+    await updateRef.current(id, { openingBalance: toMoneyString(amount) });
+    await refresh();
+  }, [ensureBudgetId, refresh]);
+
+  const updateNotes = useCallback(async (notes: string | null) => {
+    const id = await ensureBudgetId();
+    if (!id) return;
+    await updateRef.current(id, { notes: notes ?? null });
+    await refresh();
+  }, [ensureBudgetId, refresh]);
+
+  // KPIs dérivés (plats selon ton typage)
+  const kpis = useMemo(() => {
+    if (!summary) return null;
+    const opening = num(summary.openingBalance);
+
+    const plannedIn = num(summary.plannedIncome);
+    const plannedOut = num(summary.plannedExpense);
+    const netPlanned = num(summary.netPlanned);
+    const projectedEndBalance = num(summary.projectedEndBalance);
+
+    const actualIn = num(summary.actualInFlow);
+    const actualOut = num(summary.actualOutFlow);
+    const netActual = num(summary.netActual);
+    const endingBalance = num(summary.endingBalance);
+
+    const clearedIn = num(summary.clearedInFlow);
+    const clearedOut = num(summary.clearedOutFlow);
+    const netCleared = num(summary.netCleared);
+    const clearedEndingBalance = num(summary.clearedEndingBalance);
+
+    return {
+      opening,
+      plannedIn,
+      plannedOut,
+      netPlanned,
+      projectedEndBalance,
+      actualIn,
+      actualOut,
+      netActual,
+      endingBalance,
+      clearedIn,
+      clearedOut,
+      netCleared,
+      clearedEndingBalance,
+    };
+  }, [summary]);
+
+  return {
+    // état
+    month,
+    setMonth, goPrevMonth, goNextMonth,
+    summary,
+    loading,
+    kpis,
+
+    // actions
+    refresh,
+    lock, unlock,
+    updateOpening, updateNotes,
+  };
+}

--- a/src/hooks/useDebouncedValue.ts
+++ b/src/hooks/useDebouncedValue.ts
@@ -1,0 +1,11 @@
+// src/hooks/useDebouncedValue.ts
+import { useEffect, useState } from "react";
+
+export function useDebouncedValue<T>(value: T, delay = 300) {
+  const [v, setV] = useState<T>(value);
+  useEffect(() => {
+    const t = setTimeout(() => setV(value), delay);
+    return () => clearTimeout(t);
+  }, [value, delay]);
+  return v;
+}

--- a/src/hooks/useExpenses.ts
+++ b/src/hooks/useExpenses.ts
@@ -1,0 +1,126 @@
+// src/hooks/useExpenses.ts
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useSessionStore } from "@/stores/sessionStore";
+import { useExpensesService } from "@/lib/service/expense.service";
+import type { Expense } from "@/types";
+
+type CreateOrUpdatePayload = {
+  label: string;
+  amount: number | string; // l'UI peut fournir number
+  day: number;
+  bankAccountId: string;
+  memberId: string;
+  isArchived?: boolean;
+};
+
+export function useExpenses() {
+  const { currentSessionId } = useSessionStore();
+  const svc = useExpensesService();
+
+  // stabilisation des méthodes
+  const listRef = useRef(svc.listBySession);
+  const createRef = useRef(svc.create);
+  const updateRef = useRef(svc.update);
+  const removeRef = useRef(svc.remove);
+  const archiveRef = useRef(svc.archive);
+  const restoreRef = useRef(svc.restore);
+  useEffect(() => {
+    listRef.current = svc.listBySession;
+    createRef.current = svc.create;
+    updateRef.current = svc.update;
+    removeRef.current = svc.remove;
+    archiveRef.current = svc.archive;
+    restoreRef.current = svc.restore;
+  }, [svc]);
+
+  const [loading, setLoading] = useState(false);
+  const [expenses, setExpenses] = useState<Expense[]>([]);
+  const [showArchived, setShowArchived] = useState(false);
+  const inFlight = useRef(false);
+
+  const refresh = useCallback(async (sid?: string) => {
+    const sessionId = sid ?? currentSessionId;
+    if (!sessionId) return;
+    if (inFlight.current) return;
+    inFlight.current = true;
+    setLoading(true);
+    try {
+      const list = await listRef.current(sessionId);
+      setExpenses(list);
+    } finally {
+      setLoading(false);
+      inFlight.current = false;
+    }
+  }, [currentSessionId]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const visible = useMemo(() => {
+    const base = showArchived ? expenses : expenses.filter(e => !e.isArchived);
+    return [...base].sort((a, b) => {
+      if (a.day !== b.day) return a.day - b.day;
+      return a.label.localeCompare(b.label);
+    });
+  }, [expenses, showArchived]);
+
+  // helpers conversion amount -> string "xx.yy"
+  function toApiAmount(v: number | string) {
+    const n = typeof v === "number" ? v : Number(String(v).replace(",", "."));
+    const safe = Number.isFinite(n) ? n : 0;
+    return safe.toFixed(2);
+  }
+
+  async function createExpense(input: CreateOrUpdatePayload) {
+    if (!currentSessionId) return;
+    await createRef.current({
+      sessionId: currentSessionId,
+      label: input.label,
+      amount: toApiAmount(input.amount),
+      day: input.day,
+      bankAccountId: input.bankAccountId,
+      memberId: input.memberId,
+      isArchived: input.isArchived,
+    });
+    await refresh();
+  }
+
+  async function updateExpense(id: string, input: Partial<CreateOrUpdatePayload>) {
+    const dto: any = { ...input };
+    if (input.amount != null) dto.amount = toApiAmount(input.amount);
+    await updateRef.current(id, dto);
+    await refresh();
+  }
+
+  async function deleteExpense(id: string) {
+    await removeRef.current(id);
+    await refresh();
+  }
+
+  async function archiveExpense(id: string) {
+    await archiveRef.current(id);
+    await refresh();
+  }
+
+  async function restoreExpense(id: string) {
+    await restoreRef.current(id);
+    await refresh();
+  }
+
+  return {
+    currentSessionId,
+    loading,
+    expenses,
+    visibleExpenses: visible,
+    showArchived,
+    setShowArchived,
+
+    refresh,
+    createExpense,
+    updateExpense,
+    deleteExpense,
+    archiveExpense,
+    restoreExpense,
+  };
+}

--- a/src/hooks/useExpenses.ts
+++ b/src/hooks/useExpenses.ts
@@ -8,6 +8,7 @@ type CreateOrUpdatePayload = {
   label: string;
   amount: number | string; // l'UI peut fournir number
   day: number;
+  category: Expense["category"];
   bankAccountId: string;
   memberId: string;
   isArchived?: boolean;
@@ -79,6 +80,7 @@ export function useExpenses() {
       label: input.label,
       amount: toApiAmount(input.amount),
       day: input.day,
+      category: input.category,
       bankAccountId: input.bankAccountId,
       memberId: input.memberId,
       isArchived: input.isArchived,

--- a/src/hooks/useIncomes.ts
+++ b/src/hooks/useIncomes.ts
@@ -1,0 +1,48 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useSessionStore } from "@/stores/sessionStore";
+import { useIncomesService } from "@/lib/service/income.service";
+import type { Income } from "@/types";
+
+export function useIncomes() {
+  const { currentSessionId } = useSessionStore();
+  const svc = useIncomesService();
+
+  // refs pour stabiliser les méthodes du service
+  const listBySessionRef = useRef(svc.getBySession);
+  useEffect(() => {
+    listBySessionRef.current = svc.getBySession;
+  }, [svc]);
+
+  const [incomes, setIncomes] = useState<Income[]>([]);
+  const [loading, setLoading] = useState(false);
+  const inFlightRef = useRef(false);
+
+  const refresh = useCallback(
+    async (sessionId?: string) => {
+      const sid = sessionId ?? currentSessionId;
+      if (!sid) return;
+      if (inFlightRef.current) return;
+      inFlightRef.current = true;
+      setLoading(true);
+      try {
+        const list = await listBySessionRef.current(sid);
+        setIncomes(list);
+      } finally {
+        setLoading(false);
+        inFlightRef.current = false;
+      }
+    },
+    [currentSessionId]
+  );
+
+  useEffect(() => {
+    void refresh(); // au mount & quand currentSessionId change
+  }, [refresh]);
+
+  return {
+    currentSessionId,
+    incomes,
+    loading,
+    refresh,
+  };
+}

--- a/src/hooks/useTransactions.ts
+++ b/src/hooks/useTransactions.ts
@@ -1,0 +1,193 @@
+// src/hooks/useTransactions.ts
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useSessionStore } from "@/stores/sessionStore";
+import { useTransactionsService } from "@/lib/service/transaction.service";
+import type {
+  DateRange,
+  MonthRange,
+  Transaction,
+  TransactionId,
+  CreateTransactionDto,
+  UpdateTransactionDto,
+  MonthString,
+} from "@/types";
+
+function monthToRange(month: MonthString): DateRange {
+  // month: "YYYY-MM"
+  const [y, m] = month.split("-").map(Number);
+  const from = new Date(y, m - 1, 1);
+  const to = new Date(y, m, 0); // last day of month
+  const iso = (d: Date) => d.toISOString().slice(0, 10);
+  return { from: iso(from), to: iso(to) };
+}
+function toMoneyString(v: number | string) {
+  const n = typeof v === "number" ? v : Number(String(v).replace(",", "."));
+  const safe = Number.isFinite(n) ? n : 0;
+  return safe.toFixed(2);
+}
+
+type ClearedFilter = "ALL" | "CLEARED" | "UNCLEARED";
+
+export function useTransactions(input?: Partial<DateRange & MonthRange>) {
+  const { currentSessionId } = useSessionStore();
+  const svc = useTransactionsService();
+
+  // Stabiliser méthodes (StrictMode)
+  const listRef = useRef(svc.listBySession);
+  const createRef = useRef(svc.create);
+  const updateRef = useRef(svc.update);
+  const removeRef = useRef(svc.remove);
+  useEffect(() => {
+    listRef.current = svc.listBySession;
+    createRef.current = svc.create;
+    updateRef.current = svc.update;
+    removeRef.current = svc.remove;
+  }, [svc]);
+
+  // Période : priorité à {from,to}, sinon {month}, sinon mois courant
+  const [range, setRange] = useState<DateRange>(() => {
+    if (input?.from && input?.to) return { from: input.from, to: input.to };
+    const month: MonthString =
+      (input as any)?.month ??
+      `${new Date().getFullYear()}-${String(new Date().getMonth() + 1).padStart(2, "0")}`;
+    return monthToRange(month);
+  });
+  const setMonth = useCallback((m: MonthString) => setRange(monthToRange(m)), []);
+
+  // Filtres client
+  const [bankAccountId, setBankAccountId] = useState<string | null>(null);
+  const [memberId, setMemberId] = useState<string | null>(null);
+  const [cleared, setCleared] = useState<ClearedFilter>("ALL");
+  const [query, setQuery] = useState<string>("");
+
+  // Données
+  const [items, setItems] = useState<Transaction[]>([]);
+  const [loading, setLoading] = useState(false);
+  const inFlight = useRef(false);
+
+  const refresh = useCallback(async () => {
+    if (!currentSessionId) return;
+    if (inFlight.current) return;
+    inFlight.current = true;
+    setLoading(true);
+    try {
+      const list = await listRef.current(currentSessionId, {
+        from: range.from,
+        to: range.to,
+      });
+      setItems(Array.isArray(list) ? list : []);
+    } finally {
+      setLoading(false);
+      inFlight.current = false;
+    }
+  }, [currentSessionId, range.from, range.to]);
+
+  useEffect(() => {
+    void refresh(); // mount + changement de période/session
+  }, [refresh]);
+
+  // Helpers CRUD
+  const createTx = useCallback(
+    async (data: Omit<CreateTransactionDto, "amount" | "sessionId"> & { amount: number | string }) => {
+      if (!currentSessionId) return null;
+      const dto: CreateTransactionDto = {
+        ...data,
+        sessionId: currentSessionId,
+        amount: toMoneyString(data.amount),
+      };
+      const created = await createRef.current(dto);
+      await refresh();
+      return created;
+    },
+    [currentSessionId, refresh]
+  );
+
+  const updateTx = useCallback(
+    async (
+        id: TransactionId,
+        data: { amount?: number | string } & Omit<UpdateTransactionDto, "amount">
+    ) => {
+        const { amount, ...rest } = data; // <-- on retire amount du spread
+        const dto: UpdateTransactionDto = {
+        ...rest,
+        ...(amount !== undefined ? { amount: toMoneyString(amount) } : {}),
+        };
+        const updated = await updateRef.current(id, dto);
+        await refresh();
+        return updated;
+    },
+    [refresh]
+  );
+
+  const toggleCleared = useCallback(
+    async (id: TransactionId, current?: boolean) => {
+      const updated = await updateRef.current(id, { isCleared: !current });
+      await refresh();
+      return updated;
+    },
+    [refresh]
+  );
+
+  const removeTx = useCallback(
+    async (id: TransactionId) => {
+      await removeRef.current(id);
+      await refresh();
+    },
+    [refresh]
+  );
+
+  // Dérivés filtrés/sortis
+  const visible = useMemo(() => {
+    let rows = items.slice();
+    if (bankAccountId) rows = rows.filter((r) => r.bankAccountId === bankAccountId);
+    if (memberId) rows = rows.filter((r) => r.memberId === memberId);
+    if (cleared !== "ALL") rows = rows.filter((r) => !!r.isCleared === (cleared === "CLEARED"));
+    if (query.trim()) {
+      const q = query.trim().toLowerCase();
+      rows = rows.filter((r) => r.label?.toLowerCase().includes(q) || r.notes?.toLowerCase().includes(q));
+    }
+    // Tri date DESC puis id DESC
+    rows.sort((a, b) => (a.date < b.date ? 1 : a.date > b.date ? -1 : a.id < b.id ? 1 : -1));
+    return rows;
+  }, [items, bankAccountId, memberId, cleared, query]);
+
+  // Totaux de la période filtrée (client)
+  const totals = useMemo(() => {
+    return visible.reduce(
+      (acc, t) => {
+        const n = typeof t.amount === "number" ? t.amount : Number(String(t.amount).replace(",", "."));
+        const val = Number.isFinite(n) ? n : 0;
+        if (t.type === "INFLOW") acc.in += val;
+        else acc.out += val;
+        return acc;
+      },
+      { in: 0, out: 0 }
+    );
+  }, [visible]);
+
+  return {
+    // état
+    items,
+    visible,     // liste filtrée/triée pour l’UI
+    loading,
+    range,
+    setRange,
+    setMonth,
+
+    // filtres
+    bankAccountId, setBankAccountId,
+    memberId, setMemberId,
+    cleared, setCleared,
+    query, setQuery,
+
+    // actions
+    refresh,
+    createTx,
+    updateTx,
+    toggleCleared,
+    removeTx,
+
+    // totaux
+    totals,
+  };
+}

--- a/src/hooks/useTxUrlState.ts
+++ b/src/hooks/useTxUrlState.ts
@@ -1,0 +1,44 @@
+// src/hooks/useTxUrlState.ts
+import { useCallback, useMemo } from "react";
+import { useSearchParams } from "react-router-dom";
+
+export type ClearedFilter = "ALL" | "CLEARED" | "UNCLEARED";
+
+type State = {
+  month?: string | null;      // "YYYY-MM"
+  bank?: string | null;
+  member?: string | null;
+  cleared?: ClearedFilter;
+  q?: string | null;
+};
+
+function getOrNull(v: string | null) {
+  return v && v.length ? v : null;
+}
+
+export function useTxUrlState(defaults?: Required<State>) {
+  const [sp, setSp] = useSearchParams();
+
+  const state: Required<State> = useMemo(() => {
+    return {
+      month: getOrNull(sp.get("month")) ?? defaults?.month ?? "",
+      bank: getOrNull(sp.get("bank")) ?? null,
+      member: getOrNull(sp.get("member")) ?? null,
+      cleared: (getOrNull(sp.get("cleared")) as ClearedFilter) ?? (defaults?.cleared ?? "ALL"),
+      q: getOrNull(sp.get("q")) ?? "",
+    };
+  }, [sp, defaults]);
+
+  const set = useCallback((next: Partial<State>, opts?: { replace?: boolean }) => {
+    const n = new URLSearchParams(sp);
+    const entries: [keyof State, any][] = Object.entries(next) as any;
+    for (const [k, v] of entries) {
+      if (v === undefined) continue;
+      if (v === null || v === "" || (k === "cleared" && v === "ALL")) n.delete(k);
+      else n.set(k, String(v));
+    }
+    setSp(n, { replace: opts?.replace ?? true });
+  }, [sp, setSp]);
+
+  return [state, set] as const;
+}

--- a/src/i18n/resources/en.json
+++ b/src/i18n/resources/en.json
@@ -71,7 +71,8 @@
     "cancel": "Cancel",
     "delete": "Delete",
     "save": "Save",
-    "edit": "Edit"
+    "edit": "Edit",
+    "refresh": "Refresh"
   },
   "sessions": {
     "selector": {
@@ -451,6 +452,9 @@
     "delete": {
       "title": "Delete transaction?",
       "desc": "This action cannot be undone."
+    },
+    "a11y": {
+      "toggleCleared": "Toggle cleared: {{label}}"
     }
   },
   "categories": {

--- a/src/i18n/resources/en.json
+++ b/src/i18n/resources/en.json
@@ -337,5 +337,52 @@
       "archived": "Expense archived.",
       "restored": "Expense restored."
     }
+  },
+  "budgets": {
+    "actions": {
+      "lock": "Lock",
+      "unlock": "Unlock",
+      "editOpening": "Opening balance",
+      "editNotes": "Notes"
+    },
+    "opening": {
+      "title": "Edit opening balance",
+      "desc": "Enter the opening balance for this month.",
+      "label": "Balance"
+    },
+    "notes": {
+      "title": "Edit notes",
+      "titleShort": "Notes",
+      "desc": "Add helpful context for this month.",
+      "placeholder": "Month notes…",
+      "empty": "No notes for this month."
+    },
+    "kpi": {
+      "opening": "Opening",
+      "plannedIn": "Planned (In)",
+      "plannedOut": "Planned (Out)",
+      "netPlanned": "Net planned",
+      "projectedEnd": "Projected closing",
+      "actualIn": "Actual (In)",
+      "actualOut": "Actual (Out)",
+      "netActual": "Net actual",
+      "ending": "Closing",
+      "clearedIn": "Cleared (In)",
+      "clearedOut": "Cleared (Out)",
+      "netCleared": "Net cleared"
+    },
+    "hints": {
+      "netPlanned": "Planned income − planned expense"
+    },
+    "empty": {
+      "noSessionTitle": "No active session",
+      "noSessionDesc": "Select or create a session to view budgets.",
+      "title": "No budget data",
+      "desc": "The summary will be created automatically if needed."
+    },
+    "toasts": {
+      "locked": "Budget locked.",
+      "unlocked": "Budget unlocked."
+    }
   }
 }

--- a/src/i18n/resources/en.json
+++ b/src/i18n/resources/en.json
@@ -275,5 +275,67 @@
       "updated": "Income updated.",
       "deleted": "Income deleted."
     }
+  },
+  "expenses": {
+    "actions": {
+      "new": "New expense",
+      "archive": "Archive",
+      "restore": "Restore",
+      "showArchived": "Show archived",
+      "hideArchived": "Hide archived"
+    },
+    "badges": { "archived": "Archived" },
+    "fields": { "day": "Day" },
+    "categories": {
+      "housing": "Housing",
+      "utilities": "Utilities",
+      "health": "Health",
+      "food": "Food",
+      "transport": "Transport",
+      "subscriptions": "Subscriptions",
+      "other": "Other"
+    },
+    "form": {
+      "createTitle": "New planned expense",
+      "createDesc": "Add a monthly recurring expense.",
+      "editTitle": "Edit expense",
+      "editDesc": "Update expense details.",
+      "label": "Label",
+      "labelPh": "e.g. Rent",
+      "amount": "Amount",
+      "day": "Day of month",
+      "category": "Category",
+      "categoryPh": "Select a category…",
+      "bank": "Bank account",
+      "bankPh": "Select an account…",
+      "member": "Member",
+      "memberPh": "Select a member…"
+    },
+    "table": {
+      "day": "Day",
+      "label": "Label",
+      "amount": "Amount",
+      "category": "Category",
+      "bank": "Account",
+      "member": "Member",
+      "actions": "Actions"
+    },
+    "empty": {
+      "noSessionTitle": "No active session",
+      "noSessionDesc": "Select or create a session to manage expenses.",
+      "title": "No planned expenses",
+      "desc": "Create your first expense to get started."
+    },
+    "delete": {
+      "title": "Delete this expense?",
+      "desc": "This action is irreversible. \"{{label}}\" will be deleted."
+    },
+    "toasts": {
+      "created": "Expense created.",
+      "updated": "Expense updated.",
+      "deleted": "Expense deleted.",
+      "archived": "Expense archived.",
+      "restored": "Expense restored."
+    }
   }
 }

--- a/src/i18n/resources/en.json
+++ b/src/i18n/resources/en.json
@@ -383,6 +383,22 @@
     "toasts": {
       "locked": "Budget locked.",
       "unlocked": "Budget unlocked."
+    },
+     "hero": {
+      "projected": "Projected closing (Planned)",
+      "ending": "Closing (Actual)",
+      "clearedEnding": "Cleared closing"
+    },
+    "rows": {
+      "opening": "Opening",
+      "in": "Inflow",
+      "out": "Outflow",
+      "net": "Net",
+      "base": "Base (Closing)"
+    },
+    "compare": {
+      "inflow": "Inflow comparison",
+      "outflow": "Outflow comparison"
     }
   }
 }

--- a/src/i18n/resources/en.json
+++ b/src/i18n/resources/en.json
@@ -70,7 +70,8 @@
     "create": "Create",
     "cancel": "Cancel",
     "delete": "Delete",
-    "save": "Save"
+    "save": "Save",
+    "edit": "Edit"
   },
   "sessions": {
     "selector": {
@@ -232,6 +233,47 @@
       "cta": "Accept invitation",
       "success": "Invitation accepted.",
       "error": "Failed to accept."
+    }
+  },
+  "incomes": {
+    "actions": { "new": "New income" },
+    "fields": { "day": "Day" },
+    "form": {
+      "createTitle": "New planned income",
+      "createDesc": "Add a monthly recurring income.",
+      "editTitle": "Edit income",
+      "editDesc": "Update income details.",
+      "label": "Label",
+      "labelPh": "e.g. Salary",
+      "amount": "Amount",
+      "day": "Day of month",
+      "bank": "Bank account",
+      "bankPh": "Select an account…",
+      "member": "Member",
+      "memberPh": "Select a member…"
+    },
+    "table": {
+      "day": "Day",
+      "label": "Label",
+      "amount": "Amount",
+      "bank": "Account",
+      "member": "Member",
+      "actions": "Actions"
+    },
+    "empty": {
+      "noSessionTitle": "No active session",
+      "noSessionDesc": "Select or create a session to manage incomes.",
+      "title": "No planned income",
+      "desc": "Create your first income to get started."
+    },
+    "delete": {
+      "title": "Delete this income?",
+      "desc": "This action is irreversible. \"{{label}}\" will be deleted."
+    },
+    "toasts": {
+      "created": "Income created.",
+      "updated": "Income updated.",
+      "deleted": "Income deleted."
     }
   }
 }

--- a/src/i18n/resources/en.json
+++ b/src/i18n/resources/en.json
@@ -400,5 +400,66 @@
       "inflow": "Inflow comparison",
       "outflow": "Outflow comparison"
     }
+  },
+  "tx": {
+    "actions": { "new": "New transaction" },
+    "filters": {
+      "search": "Search",
+      "searchPh": "Label or note…",
+      "bank": "Account",
+      "bankPh": "Select an account",
+      "member": "Member",
+      "memberPh": "Select a member",
+      "any": "Any",
+      "cleared": "Cleared",
+      "clearedAll": "All",
+      "clearedYes": "Cleared",
+      "clearedNo": "Uncleared"
+    },
+    "totals": { "in": "Inflow", "out": "Outflow", "net": "Net" },
+    "table": {
+      "date": "Date", "label": "Label", "account": "Account",
+      "member": "Member", "amount": "Amount", "category": "Category",
+      "cleared": "Cleared", "actions": "Actions"
+    },
+    "form": {
+      "titleCreate": "Create transaction",
+      "titleEdit": "Edit transaction",
+      "description": "Fill in the fields below.",
+      "type": "Type",
+      "date": "Date",
+      "label": "Label",
+      "labelPh": "e.g. Groceries, transfer, salary…",
+      "amount": "Amount",
+      "bank": "Bank account",
+      "bankPh": "Select an account",
+      "member": "Member",
+      "memberPh": "Select a member",
+      "memberNone": "None",
+      "category": "Category",
+      "categoryPh": "Category (optional)",
+      "categoryNone": "None",
+      "notes": "Notes"
+    },
+    "types": { "inflow": "Inflow", "outflow": "Outflow" },
+    "empty": {
+      "noSessionTitle": "No active session",
+      "noSessionDesc": "Select or create a session to manage transactions.",
+      "title": "No transactions",
+      "desc": "Create your first transaction this month."
+    },
+    "delete": {
+      "title": "Delete transaction?",
+      "desc": "This action cannot be undone."
+    }
+  },
+  "categories": {
+    "FOOD": "Food",
+    "HOUSING": "Housing",
+    "UTILITIES": "Utilities",
+    "HEALTH": "Health",
+    "TRANSPORT": "Transport",
+    "SUBSCRIPTIONS": "Subscriptions",
+    "OTHER": "Other"
   }
 }

--- a/src/i18n/resources/fr.json
+++ b/src/i18n/resources/fr.json
@@ -71,7 +71,8 @@
     "cancel": "Annuler",
     "delete": "Supprimer",
     "save": "Enregistrer",
-    "edit": "Éditer"
+    "edit": "Éditer",
+    "refresh": "Rafraîchir"
   },
   "sessions": {
     "selector": {
@@ -452,6 +453,9 @@
     "delete": {
       "title": "Supprimer la transaction ?",
       "desc": "Cette action est irréversible."
+    },
+    "a11y": {
+      "toggleCleared": "Basculer pointage : {{label}}"
     }
   },
   "categories": {

--- a/src/i18n/resources/fr.json
+++ b/src/i18n/resources/fr.json
@@ -70,7 +70,8 @@
     "create": "Créer",
     "cancel": "Annuler",
     "delete": "Supprimer",
-    "save": "Enregistrer"
+    "save": "Enregistrer",
+    "edit": "Éditer"
   },
   "sessions": {
     "selector": {
@@ -232,6 +233,48 @@
       "cta": "Accepter l'invitation",
       "success": "Invitation acceptée.",
       "error": "Échec de l'acceptation."
+    }
+  },
+
+  "incomes": {
+    "actions": { "new": "Nouveau revenu" },
+    "fields": { "day": "Jour" },
+    "form": {
+      "createTitle": "Nouveau revenu planifié",
+      "createDesc": "Ajoute un revenu récurrent au mois.",
+      "editTitle": "Modifier le revenu",
+      "editDesc": "Mets à jour les informations du revenu.",
+      "label": "Intitulé",
+      "labelPh": "Ex. Salaire",
+      "amount": "Montant",
+      "day": "Jour du mois",
+      "bank": "Compte bancaire",
+      "bankPh": "Sélectionner un compte…",
+      "member": "Membre",
+      "memberPh": "Sélectionner un membre…"
+    },
+    "table": {
+      "day": "Jour",
+      "label": "Intitulé",
+      "amount": "Montant",
+      "bank": "Compte",
+      "member": "Membre",
+      "actions": "Actions"
+    },
+    "empty": {
+      "noSessionTitle": "Aucune session active",
+      "noSessionDesc": "Sélectionne ou crée une session pour gérer les revenus.",
+      "title": "Aucun revenu planifié",
+      "desc": "Ajoute ton premier revenu pour démarrer."
+    },
+    "delete": {
+      "title": "Supprimer ce revenu ?",
+      "desc": "Cette action est définitive. \"{{label}}\" sera supprimé."
+    },
+    "toasts": {
+      "created": "Revenu créé.",
+      "updated": "Revenu mis à jour.",
+      "deleted": "Revenu supprimé."
     }
   }
 }

--- a/src/i18n/resources/fr.json
+++ b/src/i18n/resources/fr.json
@@ -276,5 +276,67 @@
       "updated": "Revenu mis à jour.",
       "deleted": "Revenu supprimé."
     }
+  },
+  "expenses": {
+    "actions": {
+      "new": "Nouvelle dépense",
+      "archive": "Archiver",
+      "restore": "Restaurer",
+      "showArchived": "Afficher archivées",
+      "hideArchived": "Masquer archivées"
+    },
+    "badges": { "archived": "Archivée" },
+    "fields": { "day": "Jour" },
+    "categories": {
+      "housing": "Logement",
+      "utilities": "Charges",
+      "health": "Santé",
+      "food": "Alimentation",
+      "transport": "Transport",
+      "subscriptions": "Abonnements",
+      "other": "Autre"
+    },
+    "form": {
+      "createTitle": "Nouvelle dépense planifiée",
+      "createDesc": "Ajoute une dépense récurrente au mois.",
+      "editTitle": "Modifier la dépense",
+      "editDesc": "Mets à jour les informations de la dépense.",
+      "label": "Intitulé",
+      "labelPh": "Ex. Loyer",
+      "amount": "Montant",
+      "day": "Jour du mois",
+      "category": "Catégorie",
+      "categoryPh": "Sélectionner une catégorie…",
+      "bank": "Compte bancaire",
+      "bankPh": "Sélectionner un compte…",
+      "member": "Membre",
+      "memberPh": "Sélectionner un membre…"
+    },
+    "table": {
+      "day": "Jour",
+      "label": "Intitulé",
+      "amount": "Montant",
+      "category": "Catégorie",
+      "bank": "Compte",
+      "member": "Membre",
+      "actions": "Actions"
+    },
+    "empty": {
+      "noSessionTitle": "Aucune session active",
+      "noSessionDesc": "Sélectionne ou crée une session pour gérer les dépenses.",
+      "title": "Aucune dépense planifiée",
+      "desc": "Ajoute une première dépense pour démarrer."
+    },
+    "delete": {
+      "title": "Supprimer cette dépense ?",
+      "desc": "Cette action est définitive. \"{{label}}\" sera supprimée."
+    },
+    "toasts": {
+      "created": "Dépense créée.",
+      "updated": "Dépense mise à jour.",
+      "deleted": "Dépense supprimée.",
+      "archived": "Dépense archivée.",
+      "restored": "Dépense restaurée."
+    }
   }
 }

--- a/src/i18n/resources/fr.json
+++ b/src/i18n/resources/fr.json
@@ -384,6 +384,22 @@
     "toasts": {
       "locked": "Budget verrouillé.",
       "unlocked": "Budget déverrouillé."
+    },
+    "hero": {
+      "projected": "Clôture estimée (Planned)",
+      "ending": "Clôture (Actual)",
+      "clearedEnding": "Clôture pointée (Cleared)"
+    },
+    "rows": {
+      "opening": "Ouverture",
+      "in": "Entrées",
+      "out": "Sorties",
+      "net": "Net",
+      "base": "Base (Clôture)"
+    },
+    "compare": {
+      "inflow": "Comparatif Entrées",
+      "outflow": "Comparatif Sorties"
     }
   }
 }

--- a/src/i18n/resources/fr.json
+++ b/src/i18n/resources/fr.json
@@ -401,5 +401,66 @@
       "inflow": "Comparatif Entrées",
       "outflow": "Comparatif Sorties"
     }
+  },
+  "tx": {
+    "actions": { "new": "Nouvelle transaction" },
+    "filters": {
+      "search": "Recherche",
+      "searchPh": "Libellé ou note…",
+      "bank": "Compte",
+      "bankPh": "Choisir un compte",
+      "member": "Membre",
+      "memberPh": "Choisir un membre",
+      "any": "Tous",
+      "cleared": "Pointage",
+      "clearedAll": "Tous",
+      "clearedYes": "Pointées",
+      "clearedNo": "Non pointées"
+    },
+    "totals": { "in": "Entrées", "out": "Sorties", "net": "Net" },
+    "table": {
+      "date": "Date", "label": "Libellé", "account": "Compte",
+      "member": "Membre", "amount": "Montant", "category": "Catégorie",
+      "cleared": "Pointée", "actions": "Actions"
+    },
+    "form": {
+      "titleCreate": "Créer une transaction",
+      "titleEdit": "Modifier la transaction",
+      "description": "Renseigne les informations ci-dessous.",
+      "type": "Type",
+      "date": "Date",
+      "label": "Libellé",
+      "labelPh": "Ex: Courses, virement, salaire…",
+      "amount": "Montant",
+      "bank": "Compte bancaire",
+      "bankPh": "Sélectionne un compte",
+      "member": "Membre",
+      "memberPh": "Sélectionne un membre",
+      "memberNone": "Aucun",
+      "category": "Catégorie",
+      "categoryPh": "Catégorie (facultatif)",
+      "categoryNone": "Aucune",
+      "notes": "Notes"
+    },
+    "types": { "inflow": "Entrée", "outflow": "Sortie" },
+    "empty": {
+      "noSessionTitle": "Aucune session active",
+      "noSessionDesc": "Sélectionne ou crée une session pour gérer tes transactions.",
+      "title": "Aucune transaction",
+      "desc": "Crée ta première transaction ce mois-ci."
+    },
+    "delete": {
+      "title": "Supprimer la transaction ?",
+      "desc": "Cette action est irréversible."
+    }
+  },
+  "categories": {
+    "FOOD": "Alimentation",
+    "HOUSING": "Logement",
+    "UTILITIES": "Charges",
+    "HEALTH": "Santé",
+    "TRANSPORT": "Transport",
+    "SUBSCRIPTIONS": "Abonnements",
+    "OTHER": "Autre"
   }
 }

--- a/src/i18n/resources/fr.json
+++ b/src/i18n/resources/fr.json
@@ -32,7 +32,7 @@
     "settings": "Paramètres",
     "signup": "Inscrivez-vous",
     "login": "Connectez-vous",
-     "home": "Accueil",
+    "home": "Accueil",
     "transactions": "Transactions",
     "sessions": "Sessions"
   },
@@ -337,6 +337,53 @@
       "deleted": "Dépense supprimée.",
       "archived": "Dépense archivée.",
       "restored": "Dépense restaurée."
+    }
+  },
+  "budgets": {
+    "actions": {
+      "lock": "Verrouiller",
+      "unlock": "Déverrouiller",
+      "editOpening": "Solde d’ouverture",
+      "editNotes": "Notes"
+    },
+    "opening": {
+      "title": "Modifier le solde d’ouverture",
+      "desc": "Saisis le solde d’ouverture pour ce mois.",
+      "label": "Solde"
+    },
+    "notes": {
+      "title": "Modifier les notes",
+      "titleShort": "Notes",
+      "desc": "Ajoute des informations utiles pour ce budget.",
+      "placeholder": "Notes du mois…",
+      "empty": "Aucune note pour ce mois."
+    },
+    "kpi": {
+      "opening": "Ouverture",
+      "plannedIn": "Planifié (Entrées)",
+      "plannedOut": "Planifié (Sorties)",
+      "netPlanned": "Net planifié",
+      "projectedEnd": "Clôture estimée",
+      "actualIn": "Réel (Entrées)",
+      "actualOut": "Réel (Sorties)",
+      "netActual": "Net réel",
+      "ending": "Clôture",
+      "clearedIn": "Pointé (Entrées)",
+      "clearedOut": "Pointé (Sorties)",
+      "netCleared": "Net pointé"
+    },
+    "hints": {
+      "netPlanned": "Entrées planifiées − sorties planifiées"
+    },
+    "empty": {
+      "noSessionTitle": "Aucune session active",
+      "noSessionDesc": "Sélectionne ou crée une session pour voir le budget.",
+      "title": "Aucune donnée budgétaire",
+      "desc": "Le résumé sera généré automatiquement au besoin."
+    },
+    "toasts": {
+      "locked": "Budget verrouillé.",
+      "unlocked": "Budget déverrouillé."
     }
   }
 }

--- a/src/lib/service/budget.service.ts
+++ b/src/lib/service/budget.service.ts
@@ -1,0 +1,52 @@
+// src/lib/service/budgets.service.ts
+import { useApi } from "@/lib/api/useApi";
+import type {
+  Budget,
+  BudgetSummary,
+  CreateBudgetDto,
+  MonthString,
+  UpdateBudgetDto,
+} from "@/types";
+
+export function useBudgetsService() {
+  const { get, post, patch, del } = useApi();
+
+  // Liste des budgets d'une session
+  const listBySession = (sessionId: string) =>
+    get<Budget[]>(`/budgets/session/${sessionId}`);
+
+  // Lire un budget d'un mois précis (retourne Budget ou 404 si absent)
+  const getByMonth = (sessionId: string, month: MonthString) =>
+    get<Budget>(`/budgets/session/${sessionId}?month=${month}`);
+
+  // Créer un budget
+  const create = (dto: CreateBudgetDto) =>
+    post<Budget>("/budgets", dto);
+
+  // Modifier (openingBalance, notes, locked)
+  const update = (budgetId: string, dto: UpdateBudgetDto) =>
+    patch<Budget>(`/budgets/${budgetId}`, dto);
+
+  // Supprimer (facultatif pour QA)
+  const remove = (budgetId: string) =>
+    del<void>(`/budgets/${budgetId}`);
+
+  // Résumé du mois (source unique pour la page) + fallback auto
+  const getSummary = (
+    sessionId: string,
+    month: MonthString,
+    opts?: { createIfMissing?: boolean }
+  ) => {
+    const q = opts?.createIfMissing ? "?createIfMissing=true" : "";
+    return get<BudgetSummary>(`/budgets/session/${sessionId}/${month}/summary${q}`);
+  };
+
+  return {
+    listBySession,
+    getByMonth,
+    create,
+    update,
+    remove,
+    getSummary,
+  };
+}

--- a/src/lib/service/budget.service.ts
+++ b/src/lib/service/budget.service.ts
@@ -8,30 +8,47 @@ import type {
   UpdateBudgetDto,
 } from "@/types";
 
+function normId(input: string | { id?: string } | null | undefined): string {
+  if (!input) return "";
+  if (typeof input === "string") return input;
+  if (typeof input.id === "string") return input.id;
+  return ""; // on retourne "" => le client lèvera une erreur propre
+}
+
 export function useBudgetsService() {
   const { get, post, patch, del } = useApi();
 
-  // Liste des budgets d'une session
   const listBySession = (sessionId: string) =>
     get<Budget[]>(`/budgets/session/${sessionId}`);
 
-  // Lire un budget d'un mois précis (retourne Budget ou 404 si absent)
   const getByMonth = (sessionId: string, month: MonthString) =>
     get<Budget>(`/budgets/session/${sessionId}?month=${month}`);
 
-  // Créer un budget
   const create = (dto: CreateBudgetDto) =>
     post<Budget>("/budgets", dto);
 
-  // Modifier (openingBalance, notes, locked)
-  const update = (budgetId: string, dto: UpdateBudgetDto) =>
-    patch<Budget>(`/budgets/${budgetId}`, dto);
+  // ✅ tolère string OU objet {id}, évite /budgets/[object Object]
+  const update = (
+    budget: string | { id?: string },
+    dto: UpdateBudgetDto
+  ) => {
+    const id = normId(budget);
+    if (!id) {
+      // Déclenche une erreur claire (toaster géré par useApi)
+      throw new Error("Invalid budget id passed to update()");
+    }
+    return patch<Budget>(`/budgets/${id}`, dto);
+  };
 
-  // Supprimer (facultatif pour QA)
-  const remove = (budgetId: string) =>
-    del<void>(`/budgets/${budgetId}`);
+  // ✅ idem
+  const remove = (budget: string | { id?: string }) => {
+    const id = normId(budget);
+    if (!id) {
+      throw new Error("Invalid budget id passed to remove()");
+    }
+    return del<void>(`/budgets/${id}`);
+  };
 
-  // Résumé du mois (source unique pour la page) + fallback auto
   const getSummary = (
     sessionId: string,
     month: MonthString,

--- a/src/lib/service/expense.service.ts
+++ b/src/lib/service/expense.service.ts
@@ -1,0 +1,24 @@
+import { useApi } from "@/lib/api/useApi";
+import type { Expense, CreateExpenseDto, UpdateExpenseDto } from "@/types";
+
+export function useExpensesService() {
+  const { get, post, patch, del } = useApi();
+
+  const listBySession = (sessionId: string) =>
+    get<Expense[]>(`/expenses/session/${sessionId}`);
+
+  const create = (dto: CreateExpenseDto) =>
+    post<Expense>("/expenses", dto);
+
+  const update = (id: string, dto: UpdateExpenseDto) =>
+    patch<Expense>(`/expenses/${id}`, dto);
+
+  const remove = (id: string) =>
+    del<void>(`/expenses/${id}`);
+
+  // helpers d'archive
+  const archive = (id: string) => update(id, { isArchived: true });
+  const restore = (id: string) => update(id, { isArchived: false });
+
+  return { listBySession, create, update, remove, archive, restore };
+}

--- a/src/lib/service/income.service.ts
+++ b/src/lib/service/income.service.ts
@@ -1,0 +1,24 @@
+import { useApi } from "@/lib/api/useApi";
+import type { Income, CreateIncomeDto, UpdateIncomeDto } from "@/types";
+
+export function useIncomesService() {
+  const { get, post, patch, del } = useApi();
+
+  /** Liste les revenus planifiés d'une session */
+  const getBySession = (sessionId: string) =>
+    get<Income[]>(`/incomes/session/${sessionId}`);
+
+  /** Crée un revenu planifié */
+  const create = (dto: CreateIncomeDto) =>
+    post<Income>("/incomes", dto);
+
+  /** Met à jour un revenu existant */
+  const update = (incomeId: string, dto: UpdateIncomeDto) =>
+    patch<Income>(`/incomes/${incomeId}`, dto);
+
+  /** Supprime un revenu */
+  const remove = (incomeId: string) =>
+    del<{ success: boolean }>(`/incomes/${incomeId}`);
+
+  return { getBySession, create, update, remove };
+}

--- a/src/lib/service/index.ts
+++ b/src/lib/service/index.ts
@@ -3,3 +3,4 @@ export * from "./session.service";
 export * from "./bank-account.service";
 export * from "./member.service";
 export * from "./income.service";
+export * from "./expense.service";

--- a/src/lib/service/index.ts
+++ b/src/lib/service/index.ts
@@ -4,3 +4,4 @@ export * from "./bank-account.service";
 export * from "./member.service";
 export * from "./income.service";
 export * from "./expense.service";
+export * from "./budget.service";

--- a/src/lib/service/index.ts
+++ b/src/lib/service/index.ts
@@ -2,3 +2,4 @@ export * from "./auth.service";
 export * from "./session.service";
 export * from "./bank-account.service";
 export * from "./member.service";
+export * from "./income.service";

--- a/src/lib/service/index.ts
+++ b/src/lib/service/index.ts
@@ -5,3 +5,4 @@ export * from "./member.service";
 export * from "./income.service";
 export * from "./expense.service";
 export * from "./budget.service";
+export * from "./transaction.service";

--- a/src/lib/service/transaction.service.ts
+++ b/src/lib/service/transaction.service.ts
@@ -1,0 +1,33 @@
+import { useApi } from "@/lib/api/useApi";
+import type {
+  CreateTransactionDto,
+  UpdateTransactionDto,
+  Transaction,
+} from "@/types";
+
+export function useTransactionsService() {
+  const { get, post, patch, del } = useApi();
+
+  // GET /transactions/session/{sessionId}[?from=YYYY-MM-DD&to=YYYY-MM-DD]
+  // (Référence API) :contentReference[oaicite:2]{index=2}
+  const listBySession = (sessionId: string, params?: { from?: string; to?: string }) => {
+    const q = new URLSearchParams();
+    if (params?.from) q.set("from", params.from);
+    if (params?.to) q.set("to", params.to);
+    const suffix = q.toString() ? `?${q.toString()}` : "";
+    return get<Transaction[]>(`/transactions/session/${sessionId}${suffix}`);
+  };
+
+  // POST /transactions (INFLOW/OUTFLOW) :contentReference[oaicite:3]{index=3}
+  const create = (dto: CreateTransactionDto) =>
+    post<Transaction>("/transactions", dto);
+
+  // PATCH /transactions/{id} (mise à jour/changement cleared) :contentReference[oaicite:4]{index=4}
+  const update = (id: string, dto: UpdateTransactionDto) =>
+    patch<Transaction>(`/transactions/${id}`, dto);
+
+  // DELETE /transactions/{id} :contentReference[oaicite:5]{index=5}
+  const remove = (id: string) => del<void>(`/transactions/${id}`);
+
+  return { listBySession, create, update, remove };
+}

--- a/src/pages/budgets/index.tsx
+++ b/src/pages/budgets/index.tsx
@@ -5,7 +5,6 @@ import EmptyState from "@/components/system/EmptyState";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import MonthPicker from "@/components/budgets/MonthPicker";
-import KpiCard from "@/components/budgets/KpiCard";
 import EditOpeningDialog from "@/components/budgets/EditOpeningDialog";
 import EditNotesDialog from "@/components/budgets/EditNotesDialog";
 import { Lock, Unlock, Pencil } from "lucide-react";
@@ -14,12 +13,16 @@ import { useSessionStore } from "@/stores/sessionStore";
 import { useBudgetsService } from "@/lib/service/budget.service";
 import type { Budget } from "@/types";
 import { toast } from "sonner";
+import CompareTile from "@/components/budgets/CompareTile";
+import HeroSummary from "@/components/budgets/HeroSummary";
+import ModeTabs from "@/components/budgets/ModeTabs";
 
 function fmtEUR(v: number, lang: string) {
   return new Intl.NumberFormat(lang, { style: "currency", currency: "EUR" }).format(v);
 }
 
 export default function BudgetsPage() {
+  const [mode, setMode] = useState<"planned" | "actual" | "cleared">("planned");
   const { t, i18n } = useTranslation();
   const { currentSessionId } = useSessionStore();
   const hasSession = !!currentSessionId;
@@ -57,23 +60,29 @@ export default function BudgetsPage() {
   }
 
   return (
-    <section className="p-3 sm:p-4 lg:p-6 space-y-4">
-      <PageHeader
-        title={t("nav.budgets")}
-        description={
-          hasSession
-            ? t("pages.common.sessionBound", { id: currentSessionId })
-            : t("pages.common.noSession")
-        }
-        right={
-          <div className="flex flex-wrap gap-2">
-            <MonthPicker
-              month={month}
-              onPrev={goPrevMonth}
-              onNext={goNextMonth}
-              onChange={(m) => setMonth(m)}
-              disabled={!hasSession}
-            />
+  <section className="p-3 sm:p-4 lg:p-6 space-y-4">
+    <PageHeader
+      title={t("nav.budgets")}
+      description={
+        hasSession
+          ? t("pages.common.sessionBound", { id: currentSessionId })
+          : t("pages.common.noSession")
+      }
+      right={
+        <div className="flex flex-col sm:flex-row gap-2 sm:items-center">
+          <MonthPicker
+            month={month}
+            onPrev={goPrevMonth}
+            onNext={goNextMonth}
+            onChange={(m) => setMonth(m)}
+            disabled={!hasSession}
+          />
+          <ModeTabs
+            value={(mode as any) ?? "planned"}
+            onChange={(m) => setMode(m)}
+            disabled={!hasSession}
+          />
+          <div className="flex gap-2">
             <Button variant={locked ? "secondary" : "outline"} onClick={onToggleLock} disabled={!hasSession}>
               {locked ? <Unlock className="h-4 w-4 mr-2" /> : <Lock className="h-4 w-4 mr-2" />}
               {locked ? t("budgets.actions.unlock") : t("budgets.actions.lock")}
@@ -87,70 +96,122 @@ export default function BudgetsPage() {
               {t("budgets.actions.editNotes")}
             </Button>
           </div>
-        }
-      />
-
-      {!hasSession ? (
-        <EmptyState title={t("budgets.empty.noSessionTitle")} description={t("budgets.empty.noSessionDesc")} />
-      ) : loading && !summary ? (
-        <div className="grid gap-3 sm:gap-4 grid-cols-1 sm:grid-cols-2 xl:grid-cols-4">
-          {Array.from({ length: 8 }).map((_, i) => (
-            <Card key={i}><CardContent className="p-4"><div className="h-4 w-24 bg-muted rounded" /><div className="h-6 w-32 bg-muted rounded mt-2" /></CardContent></Card>
-          ))}
         </div>
-      ) : !summary || !kpis ? (
-        <EmptyState title={t("budgets.empty.title")} description={t("budgets.empty.desc")} />
-      ) : (
-        <>
-          {/* KPIs */}
-          <div className="grid gap-3 sm:gap-4 grid-cols-1 sm:grid-cols-2 xl:grid-cols-4">
-            <KpiCard label={t("budgets.kpi.opening")} value={fmtEUR(kpis.opening, i18n.language)} />
-            <KpiCard label={t("budgets.kpi.plannedIn")} value={fmtEUR(kpis.plannedIn, i18n.language)} tone="good" />
-            <KpiCard label={t("budgets.kpi.plannedOut")} value={fmtEUR(kpis.plannedOut, i18n.language)} tone="bad" />
-            <KpiCard label={t("budgets.kpi.netPlanned")} value={fmtEUR(kpis.netPlanned, i18n.language)} tone={kpis.netPlanned >= 0 ? "good" : "bad"} hint={t("budgets.hints.netPlanned")} />
+      }
+    />
 
-            <KpiCard label={t("budgets.kpi.projectedEnd")} value={fmtEUR(kpis.projectedEndBalance, i18n.language)} />
-            <KpiCard label={t("budgets.kpi.actualIn")} value={fmtEUR(kpis.actualIn, i18n.language)} tone="good" />
-            <KpiCard label={t("budgets.kpi.actualOut")} value={fmtEUR(kpis.actualOut, i18n.language)} tone="bad" />
-            <KpiCard label={t("budgets.kpi.netActual")} value={fmtEUR(kpis.netActual, i18n.language)} tone={kpis.netActual >= 0 ? "good" : "bad"} />
-
-            <KpiCard label={t("budgets.kpi.ending")} value={fmtEUR(kpis.endingBalance, i18n.language)} />
-            <KpiCard label={t("budgets.kpi.clearedIn")} value={fmtEUR(kpis.clearedIn, i18n.language)} tone="good" />
-            <KpiCard label={t("budgets.kpi.clearedOut")} value={fmtEUR(kpis.clearedOut, i18n.language)} tone="bad" />
-            <KpiCard label={t("budgets.kpi.netCleared")} value={fmtEUR(kpis.netCleared, i18n.language)} tone={kpis.netCleared >= 0 ? "good" : "bad"} />
-          </div>
-
-          {/* Notes */}
-          <Card className="mt-2">
+    {!hasSession ? (
+      <EmptyState title={t("budgets.empty.noSessionTitle")} description={t("budgets.empty.noSessionDesc")} />
+    ) : loading && !summary ? (
+      <div className="grid gap-3 sm:gap-4 grid-cols-1 sm:grid-cols-2">
+        {Array.from({ length: 2 }).map((_, i) => (
+          <Card key={i}>
             <CardContent className="p-4">
-              <div className="text-xs uppercase tracking-wide text-muted-foreground">{t("budgets.notes.titleShort")}</div>
-              <div className="mt-1 text-sm text-foreground whitespace-pre-wrap min-h-[1.5rem]">
-                {budgetMeta?.notes ?? t("budgets.notes.empty")}
-              </div>
+              <div className="h-4 w-28 bg-muted rounded" />
+              <div className="h-8 w-40 bg-muted rounded mt-2" />
+              <div className="h-10 w-full bg-muted rounded mt-3" />
             </CardContent>
           </Card>
-        </>
-      )}
+        ))}
+      </div>
+    ) : !summary || !kpis ? (
+      <EmptyState title={t("budgets.empty.title")} description={t("budgets.empty.desc")} />
+    ) : (
+      <>
+        {/* HERO */}
+        <HeroSummary
+          title={
+            mode === "planned"
+              ? t("budgets.hero.projected")
+              : mode === "actual"
+              ? t("budgets.hero.ending")
+              : t("budgets.hero.clearedEnding")
+          }
+          main={
+            mode === "planned"
+              ? fmtEUR(kpis.projectedEndBalance, i18n.language)
+              : mode === "actual"
+              ? fmtEUR(kpis.endingBalance, i18n.language)
+              : fmtEUR(kpis.clearedEndingBalance, i18n.language)
+          }
+          tone={
+            (mode === "planned" ? kpis.netPlanned : mode === "actual" ? kpis.netActual : kpis.netCleared) >= 0
+              ? "good"
+              : "bad"
+          }
+          rows={
+            mode === "planned"
+              ? [
+                  { label: t("budgets.rows.opening"), value: fmtEUR(kpis.opening, i18n.language) },
+                  { label: t("budgets.rows.in"), value: fmtEUR(kpis.plannedIn, i18n.language), tone: "good" },
+                  { label: t("budgets.rows.out"), value: fmtEUR(kpis.plannedOut, i18n.language), tone: "bad" },
+                  { label: t("budgets.rows.net"), value: fmtEUR(kpis.netPlanned, i18n.language), tone: kpis.netPlanned >= 0 ? "good" : "bad" },
+                ]
+              : mode === "actual"
+              ? [
+                  { label: t("budgets.rows.opening"), value: fmtEUR(kpis.opening, i18n.language) },
+                  { label: t("budgets.rows.in"), value: fmtEUR(kpis.actualIn, i18n.language), tone: "good" },
+                  { label: t("budgets.rows.out"), value: fmtEUR(kpis.actualOut, i18n.language), tone: "bad" },
+                  { label: t("budgets.rows.net"), value: fmtEUR(kpis.netActual, i18n.language), tone: kpis.netActual >= 0 ? "good" : "bad" },
+                ]
+              : [
+                  { label: t("budgets.rows.in"), value: fmtEUR(kpis.clearedIn, i18n.language), tone: "good" },
+                  { label: t("budgets.rows.out"), value: fmtEUR(kpis.clearedOut, i18n.language), tone: "bad" },
+                  { label: t("budgets.rows.net"), value: fmtEUR(kpis.netCleared, i18n.language), tone: kpis.netCleared >= 0 ? "good" : "bad" },
+                  { label: t("budgets.rows.base"), value: fmtEUR(kpis.endingBalance, i18n.language) },
+                ]
+          }
+        />
 
-      {/* Dialogs */}
-      {summary && (
-        <>
-          <EditOpeningDialog
-            open={openOpening}
-            onOpenChange={setOpenOpening}
-            initial={summary.openingBalance}
-            onSave={async (n) => { await updateOpening(n); await reloadMeta(); }}
-            disabled={locked}
+        {/* COMPARAISONS */}
+        <div className="grid gap-3 sm:gap-4 grid-cols-1 sm:grid-cols-2">
+          <CompareTile
+            title={t("budgets.compare.inflow")}
+            leftLabel="Planned"
+            leftValue={fmtEUR(kpis.plannedIn, i18n.language)}
+            rightLabel="Actual"
+            rightValue={fmtEUR(kpis.actualIn, i18n.language)}
           />
-          <EditNotesDialog
-            open={openNotes}
-            onOpenChange={setOpenNotes}
-            initial={(summary as any).notes ?? null}
-            onSave={async (txt) => { await updateNotes(txt); await reloadMeta(); }}
-            disabled={locked}
+          <CompareTile
+            title={t("budgets.compare.outflow")}
+            leftLabel="Planned"
+            leftValue={fmtEUR(kpis.plannedOut, i18n.language)}
+            rightLabel="Actual"
+            rightValue={fmtEUR(kpis.actualOut, i18n.language)}
           />
-        </>
-      )}
-    </section>
-  );
+        </div>
+
+        {/* NOTES */}
+        <Card>
+          <CardContent className="p-4">
+            <div className="text-xs uppercase tracking-wide text-muted-foreground">{t("budgets.notes.titleShort")}</div>
+            <div className="mt-1 text-sm text-foreground whitespace-pre-wrap min-h-[1.5rem]">
+              {summary?.budget?.notes ?? t("budgets.notes.empty")}
+            </div>
+          </CardContent>
+        </Card>
+      </>
+    )}
+
+    {/* Dialogs */}
+    {summary && (
+      <>
+        <EditOpeningDialog
+          open={openOpening}
+          onOpenChange={setOpenOpening}
+          initial={summary.openingBalance}
+          onSave={async (n) => { await updateOpening(n); await reloadMeta(); }}
+          disabled={locked}
+        />
+        <EditNotesDialog
+          open={openNotes}
+          onOpenChange={setOpenNotes}
+          initial={budgetMeta?.notes ?? null}
+          onSave={async (txt) => { await updateNotes(txt); await reloadMeta(); }}
+          disabled={locked}
+        />
+      </>
+    )}
+  </section>
+);
 }

--- a/src/pages/budgets/index.tsx
+++ b/src/pages/budgets/index.tsx
@@ -1,25 +1,156 @@
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useSessionStore } from "@/stores/sessionStore";
 import PageHeader from "@/components/system/PageHeader";
 import EmptyState from "@/components/system/EmptyState";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import MonthPicker from "@/components/budgets/MonthPicker";
+import KpiCard from "@/components/budgets/KpiCard";
+import EditOpeningDialog from "@/components/budgets/EditOpeningDialog";
+import EditNotesDialog from "@/components/budgets/EditNotesDialog";
+import { Lock, Unlock, Pencil } from "lucide-react";
+import { useBudgetSummary } from "@/hooks/useBudgetSummary";
+import { useSessionStore } from "@/stores/sessionStore";
+import { useBudgetsService } from "@/lib/service/budget.service";
+import type { Budget } from "@/types";
+import { toast } from "sonner";
+
+function fmtEUR(v: number, lang: string) {
+  return new Intl.NumberFormat(lang, { style: "currency", currency: "EUR" }).format(v);
+}
 
 export default function BudgetsPage() {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const { currentSessionId } = useSessionStore();
+  const hasSession = !!currentSessionId;
+
+  const { month, setMonth, goPrevMonth, goNextMonth, summary, kpis, loading, lock, unlock, updateOpening, updateNotes } =
+    useBudgetSummary();
+
+  // Récupérer meta budget (lock state) — car non présent dans BudgetSummary
+  const { getByMonth } = useBudgetsService();
+  const [budgetMeta, setBudgetMeta] = useState<Budget | null>(null);
+  async function reloadMeta() {
+    if (!currentSessionId) return setBudgetMeta(null);
+    try {
+      const b = await getByMonth(currentSessionId, month);
+      setBudgetMeta(b);
+    } catch {
+      setBudgetMeta(null);
+    }
+  }
+  useEffect(() => { void reloadMeta(); /* au mount/chgt de mois/session */ }, [currentSessionId, month]);
+
+  // Dialogs
+  const [openOpening, setOpenOpening] = useState(false);
+  const [openNotes, setOpenNotes] = useState(false);
+
+  const locked = !!budgetMeta?.locked;
+
+  async function onToggleLock() {
+    try {
+      if (locked) { await unlock(); toast.success(t("budgets.toasts.unlocked")); }
+      else { await lock(); toast.success(t("budgets.toasts.locked")); }
+    } finally {
+      await reloadMeta();
+    }
+  }
+
   return (
-    <section className="p-3 sm:p-4 lg:p-6 space-y-3 sm:space-y-4 lg:space-y-6">
+    <section className="p-3 sm:p-4 lg:p-6 space-y-4">
       <PageHeader
         title={t("nav.budgets")}
         description={
-          currentSessionId
+          hasSession
             ? t("pages.common.sessionBound", { id: currentSessionId })
             : t("pages.common.noSession")
         }
+        right={
+          <div className="flex flex-wrap gap-2">
+            <MonthPicker
+              month={month}
+              onPrev={goPrevMonth}
+              onNext={goNextMonth}
+              onChange={(m) => setMonth(m)}
+              disabled={!hasSession}
+            />
+            <Button variant={locked ? "secondary" : "outline"} onClick={onToggleLock} disabled={!hasSession}>
+              {locked ? <Unlock className="h-4 w-4 mr-2" /> : <Lock className="h-4 w-4 mr-2" />}
+              {locked ? t("budgets.actions.unlock") : t("budgets.actions.lock")}
+            </Button>
+            <Button variant="outline" onClick={() => setOpenOpening(true)} disabled={!hasSession || locked}>
+              <Pencil className="h-4 w-4 mr-2" />
+              {t("budgets.actions.editOpening")}
+            </Button>
+            <Button variant="outline" onClick={() => setOpenNotes(true)} disabled={!hasSession || locked}>
+              <Pencil className="h-4 w-4 mr-2" />
+              {t("budgets.actions.editNotes")}
+            </Button>
+          </div>
+        }
       />
-      <EmptyState
-        title={t("pages.common.emptyTitle")}
-        description={t("pages.common.emptyDesc")}
-      />
+
+      {!hasSession ? (
+        <EmptyState title={t("budgets.empty.noSessionTitle")} description={t("budgets.empty.noSessionDesc")} />
+      ) : loading && !summary ? (
+        <div className="grid gap-3 sm:gap-4 grid-cols-1 sm:grid-cols-2 xl:grid-cols-4">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <Card key={i}><CardContent className="p-4"><div className="h-4 w-24 bg-muted rounded" /><div className="h-6 w-32 bg-muted rounded mt-2" /></CardContent></Card>
+          ))}
+        </div>
+      ) : !summary || !kpis ? (
+        <EmptyState title={t("budgets.empty.title")} description={t("budgets.empty.desc")} />
+      ) : (
+        <>
+          {/* KPIs */}
+          <div className="grid gap-3 sm:gap-4 grid-cols-1 sm:grid-cols-2 xl:grid-cols-4">
+            <KpiCard label={t("budgets.kpi.opening")} value={fmtEUR(kpis.opening, i18n.language)} />
+            <KpiCard label={t("budgets.kpi.plannedIn")} value={fmtEUR(kpis.plannedIn, i18n.language)} tone="good" />
+            <KpiCard label={t("budgets.kpi.plannedOut")} value={fmtEUR(kpis.plannedOut, i18n.language)} tone="bad" />
+            <KpiCard label={t("budgets.kpi.netPlanned")} value={fmtEUR(kpis.netPlanned, i18n.language)} tone={kpis.netPlanned >= 0 ? "good" : "bad"} hint={t("budgets.hints.netPlanned")} />
+
+            <KpiCard label={t("budgets.kpi.projectedEnd")} value={fmtEUR(kpis.projectedEndBalance, i18n.language)} />
+            <KpiCard label={t("budgets.kpi.actualIn")} value={fmtEUR(kpis.actualIn, i18n.language)} tone="good" />
+            <KpiCard label={t("budgets.kpi.actualOut")} value={fmtEUR(kpis.actualOut, i18n.language)} tone="bad" />
+            <KpiCard label={t("budgets.kpi.netActual")} value={fmtEUR(kpis.netActual, i18n.language)} tone={kpis.netActual >= 0 ? "good" : "bad"} />
+
+            <KpiCard label={t("budgets.kpi.ending")} value={fmtEUR(kpis.endingBalance, i18n.language)} />
+            <KpiCard label={t("budgets.kpi.clearedIn")} value={fmtEUR(kpis.clearedIn, i18n.language)} tone="good" />
+            <KpiCard label={t("budgets.kpi.clearedOut")} value={fmtEUR(kpis.clearedOut, i18n.language)} tone="bad" />
+            <KpiCard label={t("budgets.kpi.netCleared")} value={fmtEUR(kpis.netCleared, i18n.language)} tone={kpis.netCleared >= 0 ? "good" : "bad"} />
+          </div>
+
+          {/* Notes */}
+          <Card className="mt-2">
+            <CardContent className="p-4">
+              <div className="text-xs uppercase tracking-wide text-muted-foreground">{t("budgets.notes.titleShort")}</div>
+              <div className="mt-1 text-sm text-foreground whitespace-pre-wrap min-h-[1.5rem]">
+                {budgetMeta?.notes ?? t("budgets.notes.empty")}
+              </div>
+            </CardContent>
+          </Card>
+        </>
+      )}
+
+      {/* Dialogs */}
+      {summary && (
+        <>
+          <EditOpeningDialog
+            open={openOpening}
+            onOpenChange={setOpenOpening}
+            initial={summary.openingBalance}
+            onSave={async (n) => { await updateOpening(n); await reloadMeta(); }}
+            disabled={locked}
+          />
+          <EditNotesDialog
+            open={openNotes}
+            onOpenChange={setOpenNotes}
+            initial={(summary as any).notes ?? null}
+            onSave={async (txt) => { await updateNotes(txt); await reloadMeta(); }}
+            disabled={locked}
+          />
+        </>
+      )}
     </section>
   );
 }

--- a/src/pages/expenses/index.tsx
+++ b/src/pages/expenses/index.tsx
@@ -1,25 +1,202 @@
+import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useSessionStore } from "@/stores/sessionStore";
 import PageHeader from "@/components/system/PageHeader";
 import EmptyState from "@/components/system/EmptyState";
+import { Button } from "@/components/ui/button";
+import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from "@/components/ui/table";
+import { Badge } from "@/components/ui/badge";
+import { Pencil, Trash2, Plus, Archive, ArchiveRestore } from "lucide-react";
+import { AlertDialog, AlertDialogContent, AlertDialogHeader, AlertDialogTitle, AlertDialogDescription, AlertDialogFooter, AlertDialogCancel, AlertDialogAction } from "@/components/ui/alert-dialog";
+import ExpenseFormDialog from "@/components/expenses/ExpenseFormDialog";
+import ExpenseCardItem from "@/components/expenses/ExpenseCardItem";
+import { useExpenses } from "@/hooks/useExpenses";
+import { useBanks } from "@/hooks/useBanks";
+import { useSessionStore } from "@/stores/sessionStore";
+import type { Expense } from "@/types";
+import { useExpensesService } from "@/lib/service/expense.service";
+import { toast } from "sonner";
+
+function nfmt(v: string | number | null | undefined, lang: string) {
+  const n = typeof v === "number" ? v : Number(String(v ?? "").replace(",", "."));
+  return Number.isFinite(n)
+    ? new Intl.NumberFormat(lang, { style: "currency", currency: "EUR" }).format(n)
+    : "—";
+}
 
 export default function ExpensesPage() {
-  const { t } = useTranslation();
-  const { currentSessionId } = useSessionStore();
+  const { t, i18n } = useTranslation();
+
+  const { currentSessionId, visibleExpenses, showArchived, setShowArchived, refresh, archiveExpense, restoreExpense } = useExpenses();
+  const { banks } = useBanks();
+  const { getCurrentMembers } = useSessionStore();
+  const members = getCurrentMembers();
+
+  const [open, setOpen] = useState(false);
+  const [editing, setEditing] = useState<Expense | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState<Expense | null>(null);
+
+  const { remove } = useExpensesService();
+
+  const hasSession = !!currentSessionId;
+  const list = visibleExpenses;
+
+  const banksMap = useMemo(() => new Map(banks.map((b) => [b.id, b])), [banks]);
+  const membersMap = useMemo(() => new Map(members.map((m) => [m.id, m])), [members]);
+
+  function onCreateClick() {
+    setEditing(null);
+    setOpen(true);
+  }
+  function onEditClick(e: Expense) {
+    setEditing(e);
+    setOpen(true);
+  }
+
+  async function onConfirmDelete() {
+    if (!confirmDelete) return;
+    try {
+      await remove(confirmDelete.id);
+      toast.success(t("expenses.toasts.deleted"));
+      setConfirmDelete(null);
+      await refresh();
+    } catch {}
+  }
+
+  async function onToggleArchive(e: Expense) {
+    try {
+      if (e.isArchived) {
+        await restoreExpense(e.id);
+      } else {
+        await archiveExpense(e.id);
+      }
+      toast.success(e.isArchived ? t("expenses.toasts.restored") : t("expenses.toasts.archived"));
+    } catch {}
+  }
+
   return (
-    <section className="p-3 sm:p-4 lg:p-6 space-y-3 sm:space-y-4 lg:space-y-6">
+    <section className="p-3 sm:p-4 lg:p-6 space-y-4">
       <PageHeader
         title={t("nav.expenses")}
-        description={
-          currentSessionId
-            ? t("pages.common.sessionBound", { id: currentSessionId })
-            : t("pages.common.noSession")
+        description={hasSession ? t("pages.common.sessionBound", { id: currentSessionId }) : t("pages.common.noSession")}
+        right={
+          <div className="flex flex-wrap gap-2">
+            <Button variant={showArchived ? "secondary" : "outline"} onClick={() => setShowArchived(!showArchived)} disabled={!hasSession}>
+              {showArchived ? <ArchiveRestore className="h-4 w-4 mr-2" /> : <Archive className="h-4 w-4 mr-2" />}
+              {showArchived ? t("expenses.actions.hideArchived") : t("expenses.actions.showArchived")}
+            </Button>
+            <Button onClick={onCreateClick} disabled={!hasSession}>
+              <Plus className="h-4 w-4 mr-2" /> {t("expenses.actions.new")}
+            </Button>
+          </div>
         }
       />
-      <EmptyState
-        title={t("pages.common.emptyTitle")}
-        description={t("pages.common.emptyDesc")}
-      />
+
+      {!hasSession ? (
+        <EmptyState title={t("expenses.empty.noSessionTitle")} description={t("expenses.empty.noSessionDesc")} />
+      ) : list.length === 0 ? (
+        <EmptyState
+          title={t("expenses.empty.title")}
+          description={t("expenses.empty.desc")}
+          actionLabel={t("expenses.actions.new")}
+          onAction={onCreateClick}
+        />
+      ) : (
+        <>
+          {/* Mobile cards */}
+          <div className="grid gap-2 md:hidden">
+            {list.map((e) => (
+              <ExpenseCardItem
+                key={e.id}
+                expense={e}
+                bank={banksMap.get(e.bankAccountId)}
+                member={membersMap.get(e.memberId)}
+                onEdit={onEditClick}
+                onDelete={(x) => setConfirmDelete(x)}
+                onToggleArchive={onToggleArchive}
+              />
+            ))}
+          </div>
+
+          {/* Desktop table */}
+          <div className="hidden md:block overflow-x-auto rounded-lg border">
+            <Table className="min-w-[920px]">
+              <TableHeader>
+                <TableRow>
+                  <TableHead>{t("expenses.table.day")}</TableHead>
+                  <TableHead>{t("expenses.table.label")}</TableHead>
+                  <TableHead>{t("expenses.table.amount")}</TableHead>
+                  <TableHead>{t("expenses.table.category")}</TableHead>
+                  <TableHead>{t("expenses.table.bank")}</TableHead>
+                  <TableHead>{t("expenses.table.member")}</TableHead>
+                  <TableHead className="w-[240px]">{t("expenses.table.actions")}</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {list.map((e) => {
+                  const bank = banksMap.get(e.bankAccountId);
+                  const member = membersMap.get(e.memberId);
+                  return (
+                    <TableRow key={e.id}>
+                      <TableCell className="w-[80px]"><Badge variant="secondary">{e.day}</Badge></TableCell>
+                      <TableCell className="font-medium">{e.label}{e.isArchived && <Badge className="ml-2" variant="outline">{t("expenses.badges.archived")}</Badge>}</TableCell>
+                      <TableCell>{nfmt(e.amount as any, i18n.language)}</TableCell>
+                      <TableCell><Badge variant="secondary">{t(`expenses.categories.${e.category.toLowerCase()}`)}</Badge></TableCell>
+                      <TableCell>{bank?.label ?? "—"}</TableCell>
+                      <TableCell>{member?.name ?? member?.invitedEmail ?? member?.userId ?? "—"}</TableCell>
+                      <TableCell>
+                        <div className="flex flex-wrap gap-2">
+                          <Button variant="outline" size="sm" onClick={() => onEditClick(e)}>
+                            <Pencil className="h-4 w-4 mr-2" /> {t("common.edit")}
+                          </Button>
+                          <Button variant="secondary" size="sm" onClick={() => onToggleArchive(e)}>
+                            {e.isArchived ? <ArchiveRestore className="h-4 w-4 mr-2" /> : <Archive className="h-4 w-4 mr-2" />}
+                            {e.isArchived ? t("expenses.actions.restore") : t("expenses.actions.archive")}
+                          </Button>
+                          <Button variant="destructive" size="sm" onClick={() => setConfirmDelete(e)}>
+                            <Trash2 className="h-4 w-4 mr-2" /> {t("common.delete")}
+                          </Button>
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          </div>
+        </>
+      )}
+
+      {/* Dialog create/edit */}
+      {hasSession && (
+        <ExpenseFormDialog
+          open={open}
+          onOpenChange={setOpen}
+          mode={editing ? "edit" : "create"}
+          sessionId={currentSessionId!}
+          expense={editing}
+          bankAccounts={banks}
+          members={members}
+          onSuccess={() => refresh()}
+        />
+      )}
+
+      {/* Confirm delete */}
+      <AlertDialog open={!!confirmDelete} onOpenChange={(v) => !v && setConfirmDelete(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t("expenses.delete.title")}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {t("expenses.delete.desc", { label: confirmDelete?.label ?? "" })}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>{t("common.cancel")}</AlertDialogCancel>
+            <AlertDialogAction className="bg-destructive hover:bg-destructive/90" onClick={onConfirmDelete}>
+              {t("common.delete")}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </section>
   );
 }

--- a/src/pages/incomes/index.tsx
+++ b/src/pages/incomes/index.tsx
@@ -1,26 +1,197 @@
+import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useSessionStore } from "@/stores/sessionStore";
 import PageHeader from "@/components/system/PageHeader";
 import EmptyState from "@/components/system/EmptyState";
+import { Button } from "@/components/ui/button";
+import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from "@/components/ui/table";
+import { Badge } from "@/components/ui/badge";
+import { Pencil, Trash2, Plus } from "lucide-react";
+import { AlertDialog, AlertDialogContent, AlertDialogHeader, AlertDialogTitle, AlertDialogDescription, AlertDialogFooter, AlertDialogCancel, AlertDialogAction } from "@/components/ui/alert-dialog";
+import IncomeFormDialog from "@/components/incomes/IncomeFormDialog";
+import IncomeCardItem from "@/components/incomes/IncomeCardItem";
+import { useIncomes } from "@/hooks/useIncomes"; // ← hook Étape 1 (session-aware)
+import { useBanks } from "@/hooks/useBanks";     // pour les selects
+import { useSessionStore } from "@/stores/sessionStore"; // pour les membres courant
+import type { Income } from "@/types";
+import { useIncomesService } from "@/lib/service/income.service";
+import { toast } from "sonner";
+
+function sortIncomes(list: Income[]) {
+  const copy = [...list];
+  copy.sort((a: any, b: any) => {
+    if (a.day !== b.day) return a.day - b.day;
+    return String(a.label).localeCompare(String(b.label));
+  });
+  return copy;
+}
 
 export default function IncomesPage() {
-  const { t } = useTranslation();
-  const { currentSessionId } = useSessionStore();
+  const { t, i18n } = useTranslation();
+
+  const { currentSessionId, incomes, refresh } = useIncomes();
+  const { banks } = useBanks();
+  const { getCurrentMembers } = useSessionStore();
+  const members = getCurrentMembers();
+
+  const [open, setOpen] = useState(false);
+  const [editing, setEditing] = useState<Income | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState<Income | null>(null);
+
+  const { remove } = useIncomesService();
+
+  const hasSession = !!currentSessionId;
+  const sorted = useMemo(() => sortIncomes(incomes as any), [incomes]);
+
+  const banksMap = useMemo(() => new Map(banks.map((b) => [b.id, b])), [banks]);
+  const membersMap = useMemo(() => new Map(members.map((m) => [m.id, m])), [members]);
+
+  function onCreateClick() {
+    setEditing(null);
+    setOpen(true);
+  }
+  function onEditClick(inc: Income) {
+    setEditing(inc);
+    setOpen(true);
+  }
+
+  async function onConfirmDelete() {
+    if (!confirmDelete) return;
+    try {
+      await remove((confirmDelete as any).id);
+      toast.success(t("incomes.toasts.deleted"));
+      setConfirmDelete(null);
+      await refresh();
+    } catch {
+      /* toast via useApi */
+    }
+  }
+
   return (
-    <section className="p-3 sm:p-4 lg:p-6 space-y-3 sm:space-y-4 lg:space-y-6">
+    <section className="p-3 sm:p-4 lg:p-6 space-y-4">
       <PageHeader
         title={t("nav.incomes")}
         description={
-          currentSessionId
+          hasSession
             ? t("pages.common.sessionBound", { id: currentSessionId })
             : t("pages.common.noSession")
         }
+        right={
+          <Button onClick={onCreateClick} disabled={!hasSession}>
+            <Plus className="h-4 w-4 mr-2" />
+            {t("incomes.actions.new")}
+          </Button>
+        }
       />
-      <EmptyState
-        title={t("pages.common.emptyTitle")}
-        description={t("pages.common.emptyDesc")}
-      />
+
+      {!hasSession ? (
+        <EmptyState title={t("incomes.empty.noSessionTitle")} description={t("incomes.empty.noSessionDesc")} />
+      ) : sorted.length === 0 ? (
+        <EmptyState
+          title={t("incomes.empty.title")}
+          description={t("incomes.empty.desc")}
+          actionLabel={t("incomes.actions.new")}
+          onAction={onCreateClick}
+        />
+      ) : (
+        <>
+          {/* Mobile cards */}
+          <div className="grid gap-2 md:hidden">
+            {sorted.map((inc: any) => (
+              <IncomeCardItem
+                key={inc.id}
+                income={inc}
+                bank={banksMap.get(inc.bankAccountId)}
+                member={membersMap.get(inc.memberId)}
+                onEdit={onEditClick}
+                onDelete={(i) => setConfirmDelete(i)}
+              />
+            ))}
+          </div>
+
+          {/* Desktop table */}
+          <div className="hidden md:block overflow-x-auto rounded-lg border">
+            <Table className="min-w-[820px]">
+              <TableHeader>
+                <TableRow>
+                  <TableHead>{t("incomes.table.day")}</TableHead>
+                  <TableHead>{t("incomes.table.label")}</TableHead>
+                  <TableHead>{t("incomes.table.amount")}</TableHead>
+                  <TableHead>{t("incomes.table.bank")}</TableHead>
+                  <TableHead>{t("incomes.table.member")}</TableHead>
+                  <TableHead className="w-[160px]">{t("incomes.table.actions")}</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {sorted.map((inc: any) => {
+                  const bank = banksMap.get(inc.bankAccountId);
+                  const member = membersMap.get(inc.memberId);
+                  const amount = (() => {
+                    const v = typeof inc.amount === "number" ? inc.amount : Number(String(inc.amount ?? "").replace(",", "."));
+                    return Number.isFinite(v)
+                      ? new Intl.NumberFormat(i18n.language, { style: "currency", currency: "EUR" }).format(v)
+                      : "—";
+                  })();
+                  return (
+                    <TableRow key={inc.id}>
+                      <TableCell className="w-[80px]">
+                        <Badge variant="secondary">{inc.day}</Badge>
+                      </TableCell>
+                      <TableCell className="font-medium">{inc.label}</TableCell>
+                      <TableCell>{amount}</TableCell>
+                      <TableCell>{bank?.label ?? "—"}</TableCell>
+                      <TableCell>{member?.name ?? member?.invitedEmail ?? member?.userId ?? "—"}</TableCell>
+                      <TableCell>
+                        <div className="flex flex-wrap gap-2">
+                          <Button variant="outline" size="sm" onClick={() => onEditClick(inc)}>
+                            <Pencil className="h-4 w-4 mr-2" />
+                            {t("common.edit")}
+                          </Button>
+                          <Button variant="destructive" size="sm" onClick={() => setConfirmDelete(inc)}>
+                            <Trash2 className="h-4 w-4 mr-2" />
+                            {t("common.delete")}
+                          </Button>
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          </div>
+        </>
+      )}
+
+      {/* Dialog create/edit */}
+      {hasSession && (
+        <IncomeFormDialog
+          open={open}
+          onOpenChange={setOpen}
+          mode={editing ? "edit" : "create"}
+          sessionId={currentSessionId!}
+          income={editing}
+          bankAccounts={banks}
+          members={members}
+          onSuccess={() => refresh()}
+        />
+      )}
+
+      {/* Confirm delete */}
+      <AlertDialog open={!!confirmDelete} onOpenChange={(v) => !v && setConfirmDelete(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t("incomes.delete.title")}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {t("incomes.delete.desc", { label: confirmDelete?.label ?? "" })}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>{t("common.cancel")}</AlertDialogCancel>
+            <AlertDialogAction className="bg-destructive hover:bg-destructive/90" onClick={onConfirmDelete}>
+              {t("common.delete")}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </section>
   );
 }
-

--- a/src/pages/transactions/index.tsx
+++ b/src/pages/transactions/index.tsx
@@ -23,6 +23,12 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { Card, CardContent } from "@/components/ui/card";
 import { Plus, Search, RefreshCw } from "lucide-react";
 import MonthPicker from "@/components/budgets/MonthPicker";
@@ -40,6 +46,7 @@ import {
   ListSkeleton,
   TableSkeleton,
 } from "@/components/transactions/TransactionsSkeleton";
+import { cn } from "@/lib/utils";
 
 // utils
 function fmtEUR(v: number | string, lang: string) {
@@ -133,6 +140,51 @@ export default function TransactionsPage() {
     };
     // 🔑 Dépend uniquement de la session (pas de la ref de fonction)
   }, [currentSessionId]);
+
+  function fmtDateISOToLocal(iso: string, lang: string) {
+    // supporte "YYYY-MM-DD" ou ISO
+    const d = iso?.length === 10 ? new Date(`${iso}T00:00:00`) : new Date(iso);
+    return new Intl.DateTimeFormat(lang, {
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    }).format(d);
+  }
+
+  function clsAmount(isOut: boolean) {
+    return isOut
+      ? "text-rose-600 dark:text-rose-400"
+      : "text-emerald-600 dark:text-emerald-400";
+  }
+
+  function categoryTone(cat?: string) {
+    switch (cat) {
+      case "FOOD":
+        return "bg-emerald-50 text-emerald-700 dark:bg-emerald-900/20 dark:text-emerald-300";
+      case "HOUSING":
+        return "bg-amber-50 text-amber-700 dark:bg-amber-900/20 dark:text-amber-300";
+      case "UTILITIES":
+        return "bg-sky-50 text-sky-700 dark:bg-sky-900/20 dark:text-sky-300";
+      case "HEALTH":
+        return "bg-rose-50 text-rose-700 dark:bg-rose-900/20 dark:text-rose-300";
+      case "TRANSPORT":
+        return "bg-indigo-50 text-indigo-700 dark:bg-indigo-900/20 dark:text-indigo-300";
+      case "SUBSCRIPTIONS":
+        return "bg-fuchsia-50 text-fuchsia-700 dark:bg-fuchsia-900/20 dark:text-fuchsia-300";
+      default:
+        return "bg-muted text-foreground/80";
+    }
+  }
+
+  // maps id -> label
+  const bankMap = useMemo(
+    () => Object.fromEntries(bankOptions.map((b) => [b.id, b.label])),
+    [bankOptions]
+  );
+  const memberMap = useMemo(
+    () => Object.fromEntries(memberOptions.map((m) => [m.id, m.label])),
+    [memberOptions]
+  );
 
   // Dialogs
   const [openForm, setOpenForm] = useState(false);
@@ -240,6 +292,22 @@ export default function TransactionsPage() {
     a.click();
     URL.revokeObjectURL(url);
   }
+
+  useEffect(() => {
+  function onKey(e: KeyboardEvent) {
+    if (e.key === "/" && !e.metaKey && !e.ctrlKey) {
+      e.preventDefault();
+      const el = document.querySelector<HTMLInputElement>('input[placeholder*="Libellé"], input[placeholder*="Label"]');
+      el?.focus();
+    }
+    if ((e.key === "n" || e.key === "N") && !e.metaKey && !e.ctrlKey) {
+      e.preventDefault();
+      openCreate();
+    }
+  }
+  window.addEventListener("keydown", onKey);
+  return () => window.removeEventListener("keydown", onKey);
+  }, []);
 
   return (
     <section className="p-3 sm:p-4 lg:p-6 space-y-4">
@@ -432,32 +500,27 @@ export default function TransactionsPage() {
 
           {/* Liste MOBILE */}
           <div className="grid gap-3 sm:hidden">
-            {visible.map((tx) => (
-              <TransactionCardItem
-                key={tx.id}
-                tx={tx}
-                fmt={(v) =>
-                  (tx.type === "OUTFLOW" ? "-" : "+") +
-                  " " +
-                  fmtEUR(v, i18n.language)
-                }
-                onEdit={openEdit}
-                onDelete={(t) => setConfirmId(t.id)}
-                onToggleCleared={(t) => void toggleCleared(t.id, t.isCleared)}
-              />
-            ))}
-            {visible.length === 0 && (
-              <EmptyState
-                title={t("tx.empty.title")}
-                description={t("tx.empty.desc")}
-              />
-            )}
-          </div>
+  {visible.map((tx) => (
+    <TransactionCardItem
+      key={tx.id}
+      tx={tx}
+      fmt={(v) => (tx.type === "OUTFLOW" ? "-" : "+") + " " + fmtEUR(v, i18n.language)}
+      onEdit={openEdit}
+      onDelete={(t) => setConfirmId(t.id)}
+      onToggleCleared={(t) => void toggleCleared(t.id, t.isCleared)}
+      bankLabel={bankMap[tx.bankAccountId] ?? tx.bankAccountId}
+      memberLabel={tx.memberId ? (memberMap[tx.memberId] ?? tx.memberId) : undefined}
+      dateLabel={fmtDateISOToLocal(tx.date, i18n.language)}
+    />
+  ))}
+  {visible.length === 0 && <EmptyState title={t("tx.empty.title")} description={t("tx.empty.desc")} />}
+</div>
+
 
           {/* Liste DESKTOP */}
-          <div className="hidden sm:block overflow-x-auto">
+          <div className="hidden sm:block overflow-auto max-h-[60vh]">
             <table className="w-full text-sm">
-              <thead className="text-xs text-muted-foreground">
+              <thead className="text-xs text-muted-foreground sticky top-0 bg-background z-10">
                 <tr className="text-left border-b">
                   <th className="py-2 pr-2">{t("tx.table.date")}</th>
                   <th className="py-2 pr-2">{t("tx.table.label")}</th>
@@ -476,23 +539,38 @@ export default function TransactionsPage() {
                   const isOut = tx.type === "OUTFLOW";
                   return (
                     <tr key={tx.id} className="border-b">
-                      <td className="py-2 pr-2 whitespace-nowrap">{tx.date}</td>
+                      <td className="py-2 pr-2 whitespace-nowrap">
+                        {fmtDateISOToLocal(tx.date, i18n.language)}
+                      </td>
                       <td className="py-2 pr-2">{tx.label}</td>
-                      <td className="py-2 pr-2">{tx.bankAccountId}</td>
-                      <td className="py-2 pr-2">{tx.memberId ?? "-"}</td>
+                      <td className="py-2 pr-2">
+                        {bankMap[tx.bankAccountId] ?? tx.bankAccountId}
+                      </td>
+                      <td className="py-2 pr-2">
+                        {memberMap[tx.memberId ?? ""] ?? "-"}
+                      </td>
                       <td
-                        className={`py-2 pr-2 font-medium whitespace-nowrap ${
-                          isOut
-                            ? "text-rose-600 dark:text-rose-400"
-                            : "text-emerald-600 dark:text-emerald-400"
-                        }`}
+                        className={cn(
+                          "py-2 pr-2 font-semibold whitespace-nowrap",
+                          clsAmount(isOut)
+                        )}
                       >
                         {(isOut ? "-" : "+") +
                           " " +
                           fmtEUR(tx.amount, i18n.language)}
                       </td>
                       <td className="py-2 pr-2">
-                        {(tx as any).category ?? "-"}
+                        {(tx as any).category ? (
+                          <span
+                            className={`inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-medium ${categoryTone(
+                              (tx as any).category
+                            )}`}
+                          >
+                            {(tx as any).category}
+                          </span>
+                        ) : (
+                          <span className="text-muted-foreground">-</span>
+                        )}
                       </td>
                       <td className="py-2 pr-2">
                         <Switch
@@ -506,21 +584,37 @@ export default function TransactionsPage() {
                         />
                       </td>
                       <td className="py-2 pr-2">
-                        <div className="flex gap-2">
-                          <Button
-                            size="sm"
-                            variant="outline"
-                            onClick={() => openEdit(tx)}
-                          >
-                            {t("common.edit")}
-                          </Button>
-                          <Button
-                            size="sm"
-                            variant="destructive"
-                            onClick={() => setConfirmId(tx.id)}
-                          >
-                            {t("common.delete")}
-                          </Button>
+                        <div className="flex gap-2 justify-end">
+                          <TooltipProvider>
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <Button
+                                  size="sm"
+                                  variant="outline"
+                                  onClick={() => openEdit(tx)}
+                                >
+                                  {t("common.edit")}
+                                </Button>
+                              </TooltipTrigger>
+                              <TooltipContent>
+                                {t("common.edit")}
+                              </TooltipContent>
+                            </Tooltip>
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <Button
+                                  size="sm"
+                                  variant="destructive"
+                                  onClick={() => setConfirmId(tx.id)}
+                                >
+                                  {t("common.delete")}
+                                </Button>
+                              </TooltipTrigger>
+                              <TooltipContent>
+                                {t("common.delete")}
+                              </TooltipContent>
+                            </Tooltip>
+                          </TooltipProvider>
                         </div>
                       </td>
                     </tr>
@@ -610,3 +704,5 @@ export default function TransactionsPage() {
     </section>
   );
 }
+
+

--- a/src/pages/transactions/index.tsx
+++ b/src/pages/transactions/index.tsx
@@ -1,25 +1,358 @@
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useSessionStore } from "@/stores/sessionStore";
 import PageHeader from "@/components/system/PageHeader";
 import EmptyState from "@/components/system/EmptyState";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import {
+  AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent,
+  AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle
+} from "@/components/ui/alert-dialog";
+import { Card, CardContent } from "@/components/ui/card";
+import { Plus, Search, RefreshCw } from "lucide-react";
+import MonthPicker from "@/components/budgets/MonthPicker";
+import TransactionFormDialog from "@/components/transactions/TransactionFormDialog";
+import TransactionCardItem from "@/components/transactions/TransactionCardItem";
+import { useTransactions } from "@/hooks/useTransactions";
+import { useSessionStore } from "@/stores/sessionStore";
+import { useBanks } from "@/hooks/useBanks";
+import { useSessionService } from "@/lib/service/session.service";
+import type { Transaction, TransactionCategory } from "@/types";
+
+// utils
+function fmtEUR(v: number | string, lang: string) {
+  const n = typeof v === "number" ? v : Number(String(v).replace(",", "."));
+  return new Intl.NumberFormat(lang, { style: "currency", currency: "EUR" }).format(Number.isFinite(n) ? n : 0);
+}
+function prevMonth(current: string, delta: -1 | 1) {
+  const [y, m] = current.split("-").map(Number);
+  const d = new Date(y, (m - 1) + delta, 1);
+  const yy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  return `${yy}-${mm}`;
+}
+
+type Option = { id: string; label: string };
+
+// sentinelles interdites aux chaînes vides
+const ANY = "__ANY__";
 
 export default function TransactionsPage() {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const { currentSessionId } = useSessionStore();
+
+
+  const {
+    visible, loading, range, setMonth,
+    bankAccountId, setBankAccountId,
+    memberId, setMemberId,
+    cleared, setCleared,
+    query, setQuery,
+    refresh, createTx, updateTx, toggleCleared, removeTx, totals
+  } = useTransactions();
+
+  // Comptes → options (filtrer ids vides)
+  const { banks } = useBanks();
+  const bankOptions: Option[] = (banks ?? [])
+    .map((b: any) => ({ id: String(b.id ?? ""), label: b.label ?? b.bankName ?? String(b.id ?? "") }))
+    .filter((o: Option) => o.id.trim().length > 0);
+
+  // Membres → options (fetch via service; filtrer ids vides)
+  const { getSessionMembers } = useSessionService();
+  const getSessionMembersRef = useRef(getSessionMembers);
+useEffect(() => {
+  getSessionMembersRef.current = getSessionMembers;
+}, [getSessionMembers]);
+
+const [memberOptions, setMemberOptions] = useState<Option[]>([]);
+
+useEffect(() => {
+  let alive = true;
+  async function loadMembers() {
+    if (!currentSessionId) {
+      setMemberOptions([]);
+      return;
+    }
+    try {
+      const ms = await getSessionMembersRef.current(currentSessionId);
+      if (!alive) return;
+      const opts = (ms ?? [])
+        .map((m: any) => ({
+          id: String(m.id ?? ""),
+          label: m.name ?? m.invitedEmail ?? String(m.id ?? ""),
+        }))
+        .filter((o: Option) => o.id.trim().length > 0);
+      setMemberOptions(opts);
+    } catch {
+      if (alive) setMemberOptions([]);
+    }
+  }
+  void loadMembers();
+  return () => {
+    alive = false;
+  };
+  // 🔑 Dépend uniquement de la session (pas de la ref de fonction)
+}, [currentSessionId]);
+
+  // Dialogs
+  const [openForm, setOpenForm] = useState(false);
+  const [mode, setMode] = useState<"create" | "edit">("create");
+  const [editing, setEditing] = useState<Transaction | null>(null);
+
+  // Delete confirm
+  const [confirmId, setConfirmId] = useState<string | null>(null);
+
+  const hasSession = !!currentSessionId;
+  const monthString = useMemo(() => range.from.slice(0, 7), [range.from]);
+
+  function openCreate() {
+    setMode("create");
+    setEditing(null);
+    setOpenForm(true);
+  }
+  function openEdit(tx: Transaction) {
+    setMode("edit");
+    setEditing(tx);
+    setOpenForm(true);
+  }
+
   return (
-    <section className="p-3 sm:p-4 lg:p-6 space-y-3 sm:space-y-4 lg:space-y-6">
+    <section className="p-3 sm:p-4 lg:p-6 space-y-4">
       <PageHeader
         title={t("nav.transactions")}
-        description={
-          currentSessionId
-            ? t("pages.common.sessionBound", { id: currentSessionId })
-            : t("pages.common.noSession")
+        description={hasSession ? t("pages.common.sessionBound", { id: currentSessionId }) : t("pages.common.noSession")}
+        right={
+          <div className="flex flex-col sm:flex-row gap-2 sm:items-center">
+            <MonthPicker
+              month={monthString}
+              onPrev={() => setMonth(prevMonth(monthString, -1))}
+              onNext={() => setMonth(prevMonth(monthString, +1))}
+              onChange={(m) => setMonth(m)}
+              disabled={!hasSession}
+            />
+            <Button variant="default" onClick={openCreate} disabled={!hasSession}>
+              <Plus className="h-4 w-4 mr-2" /> {t("tx.actions.new")}
+            </Button>
+            <Button variant="outline" onClick={() => refresh()} disabled={!hasSession || loading}>
+              <RefreshCw className={`h-4 w-4 mr-2 ${loading ? "animate-spin" : ""}`} /> {t("common.refresh")}
+            </Button>
+          </div>
         }
       />
-      <EmptyState
-        title={t("pages.common.emptyTitle")}
-        description={t("pages.common.emptyDesc")}
+
+      {!hasSession ? (
+        <EmptyState title={t("tx.empty.noSessionTitle")} description={t("tx.empty.noSessionDesc")} />
+      ) : (
+        <>
+          {/* Filtres */}
+          <Card>
+            <CardContent className="p-4 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
+              {/* Recherche */}
+              <div className="space-y-1">
+                <Label>{t("tx.filters.search")}</Label>
+                <div className="flex items-center gap-2">
+                  <Search className="h-4 w-4 text-muted-foreground" />
+                  <Input
+                    className="h-9"
+                    value={query}
+                    onChange={(e) => setQuery(e.target.value)}
+                    placeholder={t("tx.filters.searchPh") ?? ""}
+                  />
+                </div>
+              </div>
+
+              {/* Compte (sentinelle "__ANY__") */}
+              <div className="space-y-1">
+                <Label>{t("tx.filters.bank")}</Label>
+                <Select
+                  value={bankAccountId ?? ANY}
+                  onValueChange={(v) => setBankAccountId(v === ANY ? null : v)}
+                >
+                  <SelectTrigger><SelectValue placeholder={t("tx.filters.bankPh") ?? ""} /></SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value={ANY}>{t("tx.filters.any")}</SelectItem>
+                    {bankOptions.map((o: Option) => (
+                      <SelectItem key={o.id} value={o.id}>{o.label}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              {/* Membre (sentinelle "__ANY__") */}
+              <div className="space-y-1">
+                <Label>{t("tx.filters.member")}</Label>
+                <Select
+                  value={memberId ?? ANY}
+                  onValueChange={(v) => setMemberId(v === ANY ? null : v)}
+                >
+                  <SelectTrigger><SelectValue placeholder={t("tx.filters.memberPh") ?? ""} /></SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value={ANY}>{t("tx.filters.any")}</SelectItem>
+                    {memberOptions.map((o: Option) => (
+                      <SelectItem key={o.id} value={o.id}>{o.label}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              {/* Cleared */}
+              <div className="space-y-1">
+                <Label>{t("tx.filters.cleared")}</Label>
+                <Select value={cleared} onValueChange={(v) => setCleared(v as any)}>
+                  <SelectTrigger><SelectValue /></SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="ALL">{t("tx.filters.clearedAll")}</SelectItem>
+                    <SelectItem value="CLEARED">{t("tx.filters.clearedYes")}</SelectItem>
+                    <SelectItem value="UNCLEARED">{t("tx.filters.clearedNo")}</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Totaux */}
+          <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+            <Card>
+              <CardContent className="p-4">
+                <div className="text-xs text-muted-foreground">{t("tx.totals.in")}</div>
+                <div className="text-lg font-semibold text-emerald-600 dark:text-emerald-400">
+                  {fmtEUR(totals.in, i18n.language)}
+                </div>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardContent className="p-4">
+                <div className="text-xs text-muted-foreground">{t("tx.totals.out")}</div>
+                <div className="text-lg font-semibold text-rose-600 dark:text-rose-400">
+                  {fmtEUR(totals.out, i18n.language)}
+                </div>
+              </CardContent>
+            </Card>
+            <Card className="col-span-2 sm:col-span-1">
+              <CardContent className="p-4">
+                <div className="text-xs text-muted-foreground">{t("tx.totals.net")}</div>
+                <div className={`text-lg font-semibold ${totals.in - totals.out >= 0 ? "text-emerald-600 dark:text-emerald-400" : "text-rose-600 dark:text-rose-400"}`}>
+                  {fmtEUR(totals.in - totals.out, i18n.language)}
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+
+          {/* Liste MOBILE */}
+          <div className="grid gap-3 sm:hidden">
+            {visible.map((tx) => (
+              <TransactionCardItem
+                key={tx.id}
+                tx={tx}
+                fmt={(v) => (tx.type === "OUTFLOW" ? "-" : "+") + " " + fmtEUR(v, i18n.language)}
+                onEdit={openEdit}
+                onDelete={(t) => setConfirmId(t.id)}
+                onToggleCleared={(t) => void toggleCleared(t.id, t.isCleared)}
+              />
+            ))}
+            {visible.length === 0 && (
+              <EmptyState title={t("tx.empty.title")} description={t("tx.empty.desc")} />
+            )}
+          </div>
+
+          {/* Liste DESKTOP */}
+          <div className="hidden sm:block overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead className="text-xs text-muted-foreground">
+                <tr className="text-left border-b">
+                  <th className="py-2 pr-2">{t("tx.table.date")}</th>
+                  <th className="py-2 pr-2">{t("tx.table.label")}</th>
+                  <th className="py-2 pr-2">{t("tx.table.account")}</th>
+                  <th className="py-2 pr-2">{t("tx.table.member")}</th>
+                  <th className="py-2 pr-2">{t("tx.table.amount")}</th>
+                  <th className="py-2 pr-2">{t("tx.table.category")}</th>
+                  <th className="py-2 pr-2">{t("tx.table.cleared")}</th>
+                  <th className="py-2 pr-2 w-[120px]">{t("tx.table.actions")}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {visible.map((tx) => {
+                  const isOut = tx.type === "OUTFLOW";
+                  return (
+                    <tr key={tx.id} className="border-b">
+                      <td className="py-2 pr-2 whitespace-nowrap">{tx.date}</td>
+                      <td className="py-2 pr-2">{tx.label}</td>
+                      <td className="py-2 pr-2">{tx.bankAccountId}</td>
+                      <td className="py-2 pr-2">{tx.memberId ?? "-"}</td>
+                      <td className={`py-2 pr-2 font-medium whitespace-nowrap ${isOut ? "text-rose-600 dark:text-rose-400" : "text-emerald-600 dark:text-emerald-400"}`}>
+                        {(isOut ? "-" : "+") + " " + fmtEUR(tx.amount, i18n.language)}
+                      </td>
+                      <td className="py-2 pr-2">{(tx as any).category ?? "-"}</td>
+                      <td className="py-2 pr-2">
+                        <Switch checked={!!tx.isCleared} onCheckedChange={() => void toggleCleared(tx.id, tx.isCleared)} />
+                      </td>
+                      <td className="py-2 pr-2">
+                        <div className="flex gap-2">
+                          <Button size="sm" variant="outline" onClick={() => openEdit(tx)}>{t("common.edit")}</Button>
+                          <Button size="sm" variant="destructive" onClick={() => setConfirmId(tx.id)}>{t("common.delete")}</Button>
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+            {visible.length === 0 && (
+              <div className="py-6">
+                <EmptyState title={t("tx.empty.title")} description={t("tx.empty.desc")} />
+              </div>
+            )}
+          </div>
+        </>
+      )}
+
+      {/* Dialog create/edit */}
+      <TransactionFormDialog
+        open={openForm}
+        onOpenChange={setOpenForm}
+        mode={mode}
+        initial={editing}
+        bankOptions={bankOptions}
+        memberOptions={memberOptions}
+        onSubmit={async (v) => {
+          const base = {
+            type: v.type,
+            date: v.date,
+            label: v.label,
+            amount: v.amount,
+            bankAccountId: v.bankAccountId,
+          };
+          const optMember = v.memberId ? { memberId: v.memberId } : {};
+          const optCategory = v.category ? { category: v.category as TransactionCategory } : {};
+          const optNotes = v.notes ? { notes: v.notes } : {};
+
+          if (mode === "create") {
+            await createTx({ ...base, ...optMember, ...optCategory, ...optNotes });
+          } else if (editing) {
+            await updateTx(editing.id, { ...base, ...optMember, ...optCategory, ...optNotes });
+          }
+        }}
       />
+
+      {/* Confirm delete */}
+      <AlertDialog open={!!confirmId} onOpenChange={(o) => !o && setConfirmId(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t("tx.delete.title")}</AlertDialogTitle>
+            <AlertDialogDescription>{t("tx.delete.desc")}</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel onClick={() => setConfirmId(null)}>{t("common.cancel")}</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={async () => { if (confirmId) await removeTx(confirmId); setConfirmId(null); }}>
+              {t("common.delete")}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </section>
   );
 }

--- a/src/pages/transactions/index.tsx
+++ b/src/pages/transactions/index.tsx
@@ -5,11 +5,23 @@ import EmptyState from "@/components/system/EmptyState";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
 import {
-  AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent,
-  AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { Card, CardContent } from "@/components/ui/card";
 import { Plus, Search, RefreshCw } from "lucide-react";
@@ -21,15 +33,25 @@ import { useSessionStore } from "@/stores/sessionStore";
 import { useBanks } from "@/hooks/useBanks";
 import { useSessionService } from "@/lib/service/session.service";
 import type { Transaction, TransactionCategory } from "@/types";
+import { useTxUrlState } from "@/hooks/useTxUrlState";
+import { useDebouncedValue } from "@/hooks/useDebouncedValue";
+import {
+  FiltersSkeleton,
+  ListSkeleton,
+  TableSkeleton,
+} from "@/components/transactions/TransactionsSkeleton";
 
 // utils
 function fmtEUR(v: number | string, lang: string) {
   const n = typeof v === "number" ? v : Number(String(v).replace(",", "."));
-  return new Intl.NumberFormat(lang, { style: "currency", currency: "EUR" }).format(Number.isFinite(n) ? n : 0);
+  return new Intl.NumberFormat(lang, {
+    style: "currency",
+    currency: "EUR",
+  }).format(Number.isFinite(n) ? n : 0);
 }
 function prevMonth(current: string, delta: -1 | 1) {
   const [y, m] = current.split("-").map(Number);
-  const d = new Date(y, (m - 1) + delta, 1);
+  const d = new Date(y, m - 1 + delta, 1);
   const yy = d.getFullYear();
   const mm = String(d.getMonth() + 1).padStart(2, "0");
   return `${yy}-${mm}`;
@@ -44,58 +66,73 @@ export default function TransactionsPage() {
   const { t, i18n } = useTranslation();
   const { currentSessionId } = useSessionStore();
 
-
   const {
-    visible, loading, range, setMonth,
-    bankAccountId, setBankAccountId,
-    memberId, setMemberId,
-    cleared, setCleared,
-    query, setQuery,
-    refresh, createTx, updateTx, toggleCleared, removeTx, totals
+    visible,
+    items,
+    loading,
+    range,
+    setMonth,
+    bankAccountId,
+    setBankAccountId,
+    memberId,
+    setMemberId,
+    cleared,
+    setCleared,
+    query,
+    setQuery,
+    refresh,
+    createTx,
+    updateTx,
+    toggleCleared,
+    removeTx,
+    totals,
   } = useTransactions();
 
   // Comptes → options (filtrer ids vides)
   const { banks } = useBanks();
   const bankOptions: Option[] = (banks ?? [])
-    .map((b: any) => ({ id: String(b.id ?? ""), label: b.label ?? b.bankName ?? String(b.id ?? "") }))
+    .map((b: any) => ({
+      id: String(b.id ?? ""),
+      label: b.label ?? b.bankName ?? String(b.id ?? ""),
+    }))
     .filter((o: Option) => o.id.trim().length > 0);
 
   // Membres → options (fetch via service; filtrer ids vides)
   const { getSessionMembers } = useSessionService();
   const getSessionMembersRef = useRef(getSessionMembers);
-useEffect(() => {
-  getSessionMembersRef.current = getSessionMembers;
-}, [getSessionMembers]);
+  useEffect(() => {
+    getSessionMembersRef.current = getSessionMembers;
+  }, [getSessionMembers]);
 
-const [memberOptions, setMemberOptions] = useState<Option[]>([]);
+  const [memberOptions, setMemberOptions] = useState<Option[]>([]);
 
-useEffect(() => {
-  let alive = true;
-  async function loadMembers() {
-    if (!currentSessionId) {
-      setMemberOptions([]);
-      return;
+  useEffect(() => {
+    let alive = true;
+    async function loadMembers() {
+      if (!currentSessionId) {
+        setMemberOptions([]);
+        return;
+      }
+      try {
+        const ms = await getSessionMembersRef.current(currentSessionId);
+        if (!alive) return;
+        const opts = (ms ?? [])
+          .map((m: any) => ({
+            id: String(m.id ?? ""),
+            label: m.name ?? m.invitedEmail ?? String(m.id ?? ""),
+          }))
+          .filter((o: Option) => o.id.trim().length > 0);
+        setMemberOptions(opts);
+      } catch {
+        if (alive) setMemberOptions([]);
+      }
     }
-    try {
-      const ms = await getSessionMembersRef.current(currentSessionId);
-      if (!alive) return;
-      const opts = (ms ?? [])
-        .map((m: any) => ({
-          id: String(m.id ?? ""),
-          label: m.name ?? m.invitedEmail ?? String(m.id ?? ""),
-        }))
-        .filter((o: Option) => o.id.trim().length > 0);
-      setMemberOptions(opts);
-    } catch {
-      if (alive) setMemberOptions([]);
-    }
-  }
-  void loadMembers();
-  return () => {
-    alive = false;
-  };
-  // 🔑 Dépend uniquement de la session (pas de la ref de fonction)
-}, [currentSessionId]);
+    void loadMembers();
+    return () => {
+      alive = false;
+    };
+    // 🔑 Dépend uniquement de la session (pas de la ref de fonction)
+  }, [currentSessionId]);
 
   // Dialogs
   const [openForm, setOpenForm] = useState(false);
@@ -119,11 +156,100 @@ useEffect(() => {
     setOpenForm(true);
   }
 
+  // URL <-> état
+  const [url, setUrl] = useTxUrlState({
+    month: monthString,
+    bank: bankAccountId ?? null,
+    member: memberId ?? null,
+    cleared,
+    q: query,
+  });
+
+  // Champ de recherche "contrôlé" avec debounce
+  const [queryInput, setQueryInput] = useState(query);
+  const debouncedQuery = useDebouncedValue(queryInput, 350);
+
+  // 1) À l’arrivée sur la page ou navigation Back/Forward : pousse URL -> états
+  useEffect(() => {
+    if (url.month && url.month !== monthString) setMonth(url.month);
+    setBankAccountId(url.bank ?? null);
+    setMemberId(url.member ?? null);
+    setCleared(url.cleared);
+    setQuery(url.q ?? "");
+    setQueryInput(url.q ?? "");
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [url.month, url.bank, url.member, url.cleared, url.q]);
+
+  // 2) Quand l’utilisateur change des filtres : états -> URL
+  useEffect(() => {
+    setUrl({
+      month: monthString,
+      bank: bankAccountId ?? null,
+      member: memberId ?? null,
+      cleared,
+      q: debouncedQuery ?? "",
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [monthString, bankAccountId, memberId, cleared, debouncedQuery]);
+
+  // 3) Appliquer la recherche debounced au hook data
+  useEffect(() => {
+    setQuery(debouncedQuery ?? "");
+  }, [debouncedQuery, setQuery]);
+
+  function exportCsv(rows: Transaction[]) {
+    const head = [
+      "id",
+      "date",
+      "type",
+      "label",
+      "amount",
+      "bankAccountId",
+      "memberId",
+      "category",
+      "isCleared",
+      "notes",
+    ];
+    const esc = (v: any) => {
+      if (v === null || v === undefined) return "";
+      const s = String(v).replace(/"/g, '""');
+      return `"${s}"`;
+    };
+    const body = rows.map((r) =>
+      [
+        r.id,
+        r.date,
+        r.type,
+        r.label,
+        typeof r.amount === "number" ? r.amount.toFixed(2) : r.amount,
+        r.bankAccountId,
+        r.memberId ?? "",
+        (r as any).category ?? "",
+        r.isCleared ? "1" : "0",
+        r.notes ?? "",
+      ]
+        .map(esc)
+        .join(",")
+    );
+    const csv = [head.join(","), ...body].join("\n");
+    const blob = new Blob([csv], { type: "text/csv;charset=utf-8" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `transactions_${new Date().toISOString().slice(0, 10)}.csv`;
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+
   return (
     <section className="p-3 sm:p-4 lg:p-6 space-y-4">
       <PageHeader
         title={t("nav.transactions")}
-        description={hasSession ? t("pages.common.sessionBound", { id: currentSessionId }) : t("pages.common.noSession")}
+        description={
+          hasSession
+            ? t("pages.common.sessionBound", { id: currentSessionId })
+            : t("pages.common.noSession")
+        }
         right={
           <div className="flex flex-col sm:flex-row gap-2 sm:items-center">
             <MonthPicker
@@ -133,18 +259,47 @@ useEffect(() => {
               onChange={(m) => setMonth(m)}
               disabled={!hasSession}
             />
-            <Button variant="default" onClick={openCreate} disabled={!hasSession}>
+            <Button
+              variant="default"
+              onClick={openCreate}
+              disabled={!hasSession}
+            >
               <Plus className="h-4 w-4 mr-2" /> {t("tx.actions.new")}
             </Button>
-            <Button variant="outline" onClick={() => refresh()} disabled={!hasSession || loading}>
-              <RefreshCw className={`h-4 w-4 mr-2 ${loading ? "animate-spin" : ""}`} /> {t("common.refresh")}
+            <Button
+              variant="outline"
+              onClick={() => refresh()}
+              disabled={!hasSession || loading}
+            >
+              <RefreshCw
+                className={`h-4 w-4 mr-2 ${loading ? "animate-spin" : ""}`}
+              />{" "}
+              {t("common.refresh")}
+            </Button>
+            <Button
+              variant="outline"
+              onClick={() => exportCsv(visible)}
+              disabled={!hasSession || visible.length === 0}
+            >
+              CSV
             </Button>
           </div>
         }
       />
 
       {!hasSession ? (
-        <EmptyState title={t("tx.empty.noSessionTitle")} description={t("tx.empty.noSessionDesc")} />
+        <EmptyState
+          title={t("tx.empty.noSessionTitle")}
+          description={t("tx.empty.noSessionDesc")}
+        />
+      ) : loading && items.length === 0 ? (
+        <>
+          <FiltersSkeleton />
+          <div className="sm:hidden">
+            <ListSkeleton />
+          </div>
+          <TableSkeleton />
+        </>
       ) : (
         <>
           {/* Filtres */}
@@ -157,8 +312,8 @@ useEffect(() => {
                   <Search className="h-4 w-4 text-muted-foreground" />
                   <Input
                     className="h-9"
-                    value={query}
-                    onChange={(e) => setQuery(e.target.value)}
+                    value={queryInput}
+                    onChange={(e) => setQueryInput(e.target.value)}
                     placeholder={t("tx.filters.searchPh") ?? ""}
                   />
                 </div>
@@ -171,11 +326,15 @@ useEffect(() => {
                   value={bankAccountId ?? ANY}
                   onValueChange={(v) => setBankAccountId(v === ANY ? null : v)}
                 >
-                  <SelectTrigger><SelectValue placeholder={t("tx.filters.bankPh") ?? ""} /></SelectTrigger>
+                  <SelectTrigger>
+                    <SelectValue placeholder={t("tx.filters.bankPh") ?? ""} />
+                  </SelectTrigger>
                   <SelectContent>
                     <SelectItem value={ANY}>{t("tx.filters.any")}</SelectItem>
                     {bankOptions.map((o: Option) => (
-                      <SelectItem key={o.id} value={o.id}>{o.label}</SelectItem>
+                      <SelectItem key={o.id} value={o.id}>
+                        {o.label}
+                      </SelectItem>
                     ))}
                   </SelectContent>
                 </Select>
@@ -188,11 +347,15 @@ useEffect(() => {
                   value={memberId ?? ANY}
                   onValueChange={(v) => setMemberId(v === ANY ? null : v)}
                 >
-                  <SelectTrigger><SelectValue placeholder={t("tx.filters.memberPh") ?? ""} /></SelectTrigger>
+                  <SelectTrigger>
+                    <SelectValue placeholder={t("tx.filters.memberPh") ?? ""} />
+                  </SelectTrigger>
                   <SelectContent>
                     <SelectItem value={ANY}>{t("tx.filters.any")}</SelectItem>
                     {memberOptions.map((o: Option) => (
-                      <SelectItem key={o.id} value={o.id}>{o.label}</SelectItem>
+                      <SelectItem key={o.id} value={o.id}>
+                        {o.label}
+                      </SelectItem>
                     ))}
                   </SelectContent>
                 </Select>
@@ -201,12 +364,23 @@ useEffect(() => {
               {/* Cleared */}
               <div className="space-y-1">
                 <Label>{t("tx.filters.cleared")}</Label>
-                <Select value={cleared} onValueChange={(v) => setCleared(v as any)}>
-                  <SelectTrigger><SelectValue /></SelectTrigger>
+                <Select
+                  value={cleared}
+                  onValueChange={(v) => setCleared(v as any)}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="ALL">{t("tx.filters.clearedAll")}</SelectItem>
-                    <SelectItem value="CLEARED">{t("tx.filters.clearedYes")}</SelectItem>
-                    <SelectItem value="UNCLEARED">{t("tx.filters.clearedNo")}</SelectItem>
+                    <SelectItem value="ALL">
+                      {t("tx.filters.clearedAll")}
+                    </SelectItem>
+                    <SelectItem value="CLEARED">
+                      {t("tx.filters.clearedYes")}
+                    </SelectItem>
+                    <SelectItem value="UNCLEARED">
+                      {t("tx.filters.clearedNo")}
+                    </SelectItem>
                   </SelectContent>
                 </Select>
               </div>
@@ -214,10 +388,15 @@ useEffect(() => {
           </Card>
 
           {/* Totaux */}
-          <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+          <div
+            className="grid grid-cols-2 sm:grid-cols-3 gap-3"
+            aria-live="polite"
+          >
             <Card>
               <CardContent className="p-4">
-                <div className="text-xs text-muted-foreground">{t("tx.totals.in")}</div>
+                <div className="text-xs text-muted-foreground">
+                  {t("tx.totals.in")}
+                </div>
                 <div className="text-lg font-semibold text-emerald-600 dark:text-emerald-400">
                   {fmtEUR(totals.in, i18n.language)}
                 </div>
@@ -225,7 +404,9 @@ useEffect(() => {
             </Card>
             <Card>
               <CardContent className="p-4">
-                <div className="text-xs text-muted-foreground">{t("tx.totals.out")}</div>
+                <div className="text-xs text-muted-foreground">
+                  {t("tx.totals.out")}
+                </div>
                 <div className="text-lg font-semibold text-rose-600 dark:text-rose-400">
                   {fmtEUR(totals.out, i18n.language)}
                 </div>
@@ -233,8 +414,16 @@ useEffect(() => {
             </Card>
             <Card className="col-span-2 sm:col-span-1">
               <CardContent className="p-4">
-                <div className="text-xs text-muted-foreground">{t("tx.totals.net")}</div>
-                <div className={`text-lg font-semibold ${totals.in - totals.out >= 0 ? "text-emerald-600 dark:text-emerald-400" : "text-rose-600 dark:text-rose-400"}`}>
+                <div className="text-xs text-muted-foreground">
+                  {t("tx.totals.net")}
+                </div>
+                <div
+                  className={`text-lg font-semibold ${
+                    totals.in - totals.out >= 0
+                      ? "text-emerald-600 dark:text-emerald-400"
+                      : "text-rose-600 dark:text-rose-400"
+                  }`}
+                >
                   {fmtEUR(totals.in - totals.out, i18n.language)}
                 </div>
               </CardContent>
@@ -247,14 +436,21 @@ useEffect(() => {
               <TransactionCardItem
                 key={tx.id}
                 tx={tx}
-                fmt={(v) => (tx.type === "OUTFLOW" ? "-" : "+") + " " + fmtEUR(v, i18n.language)}
+                fmt={(v) =>
+                  (tx.type === "OUTFLOW" ? "-" : "+") +
+                  " " +
+                  fmtEUR(v, i18n.language)
+                }
                 onEdit={openEdit}
                 onDelete={(t) => setConfirmId(t.id)}
                 onToggleCleared={(t) => void toggleCleared(t.id, t.isCleared)}
               />
             ))}
             {visible.length === 0 && (
-              <EmptyState title={t("tx.empty.title")} description={t("tx.empty.desc")} />
+              <EmptyState
+                title={t("tx.empty.title")}
+                description={t("tx.empty.desc")}
+              />
             )}
           </div>
 
@@ -270,7 +466,9 @@ useEffect(() => {
                   <th className="py-2 pr-2">{t("tx.table.amount")}</th>
                   <th className="py-2 pr-2">{t("tx.table.category")}</th>
                   <th className="py-2 pr-2">{t("tx.table.cleared")}</th>
-                  <th className="py-2 pr-2 w-[120px]">{t("tx.table.actions")}</th>
+                  <th className="py-2 pr-2 w-[120px]">
+                    {t("tx.table.actions")}
+                  </th>
                 </tr>
               </thead>
               <tbody>
@@ -282,17 +480,47 @@ useEffect(() => {
                       <td className="py-2 pr-2">{tx.label}</td>
                       <td className="py-2 pr-2">{tx.bankAccountId}</td>
                       <td className="py-2 pr-2">{tx.memberId ?? "-"}</td>
-                      <td className={`py-2 pr-2 font-medium whitespace-nowrap ${isOut ? "text-rose-600 dark:text-rose-400" : "text-emerald-600 dark:text-emerald-400"}`}>
-                        {(isOut ? "-" : "+") + " " + fmtEUR(tx.amount, i18n.language)}
+                      <td
+                        className={`py-2 pr-2 font-medium whitespace-nowrap ${
+                          isOut
+                            ? "text-rose-600 dark:text-rose-400"
+                            : "text-emerald-600 dark:text-emerald-400"
+                        }`}
+                      >
+                        {(isOut ? "-" : "+") +
+                          " " +
+                          fmtEUR(tx.amount, i18n.language)}
                       </td>
-                      <td className="py-2 pr-2">{(tx as any).category ?? "-"}</td>
                       <td className="py-2 pr-2">
-                        <Switch checked={!!tx.isCleared} onCheckedChange={() => void toggleCleared(tx.id, tx.isCleared)} />
+                        {(tx as any).category ?? "-"}
+                      </td>
+                      <td className="py-2 pr-2">
+                        <Switch
+                          aria-label={t("tx.a11y.toggleCleared", {
+                            label: tx.label,
+                          })}
+                          checked={!!tx.isCleared}
+                          onCheckedChange={() =>
+                            void toggleCleared(tx.id, tx.isCleared)
+                          }
+                        />
                       </td>
                       <td className="py-2 pr-2">
                         <div className="flex gap-2">
-                          <Button size="sm" variant="outline" onClick={() => openEdit(tx)}>{t("common.edit")}</Button>
-                          <Button size="sm" variant="destructive" onClick={() => setConfirmId(tx.id)}>{t("common.delete")}</Button>
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            onClick={() => openEdit(tx)}
+                          >
+                            {t("common.edit")}
+                          </Button>
+                          <Button
+                            size="sm"
+                            variant="destructive"
+                            onClick={() => setConfirmId(tx.id)}
+                          >
+                            {t("common.delete")}
+                          </Button>
                         </div>
                       </td>
                     </tr>
@@ -302,7 +530,10 @@ useEffect(() => {
             </table>
             {visible.length === 0 && (
               <div className="py-6">
-                <EmptyState title={t("tx.empty.title")} description={t("tx.empty.desc")} />
+                <EmptyState
+                  title={t("tx.empty.title")}
+                  description={t("tx.empty.desc")}
+                />
               </div>
             )}
           </div>
@@ -326,28 +557,51 @@ useEffect(() => {
             bankAccountId: v.bankAccountId,
           };
           const optMember = v.memberId ? { memberId: v.memberId } : {};
-          const optCategory = v.category ? { category: v.category as TransactionCategory } : {};
+          const optCategory = v.category
+            ? { category: v.category as TransactionCategory }
+            : {};
           const optNotes = v.notes ? { notes: v.notes } : {};
 
           if (mode === "create") {
-            await createTx({ ...base, ...optMember, ...optCategory, ...optNotes });
+            await createTx({
+              ...base,
+              ...optMember,
+              ...optCategory,
+              ...optNotes,
+            });
           } else if (editing) {
-            await updateTx(editing.id, { ...base, ...optMember, ...optCategory, ...optNotes });
+            await updateTx(editing.id, {
+              ...base,
+              ...optMember,
+              ...optCategory,
+              ...optNotes,
+            });
           }
         }}
       />
 
       {/* Confirm delete */}
-      <AlertDialog open={!!confirmId} onOpenChange={(o) => !o && setConfirmId(null)}>
+      <AlertDialog
+        open={!!confirmId}
+        onOpenChange={(o) => !o && setConfirmId(null)}
+      >
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>{t("tx.delete.title")}</AlertDialogTitle>
-            <AlertDialogDescription>{t("tx.delete.desc")}</AlertDialogDescription>
+            <AlertDialogDescription>
+              {t("tx.delete.desc")}
+            </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel onClick={() => setConfirmId(null)}>{t("common.cancel")}</AlertDialogCancel>
+            <AlertDialogCancel onClick={() => setConfirmId(null)}>
+              {t("common.cancel")}
+            </AlertDialogCancel>
             <AlertDialogAction
-              onClick={async () => { if (confirmId) await removeTx(confirmId); setConfirmId(null); }}>
+              onClick={async () => {
+                if (confirmId) await removeTx(confirmId);
+                setConfirmId(null);
+              }}
+            >
               {t("common.delete")}
             </AlertDialogAction>
           </AlertDialogFooter>

--- a/src/types/budgets.ts
+++ b/src/types/budgets.ts
@@ -25,7 +25,7 @@ export type UpdateBudgetDto = Partial<Pick<Budget, "openingBalance" | "notes" | 
 export type BudgetSummary = {
   sessionId: string;
   month: MonthString;
-  budget?: BudgetId | null      // présent si un budget existe déjà
+  budget?: Budget | null      // présent si un budget existe déjà
   openingBalance: string;         // "1234.56"
   plannedIncome: string;          // agrégé depuis incomes/expenses
   plannedExpense: string;         // agrégé depuis incomes/expenses

--- a/src/types/budgets.ts
+++ b/src/types/budgets.ts
@@ -1,0 +1,42 @@
+export type MonthString = `${number}-${string}`; // "YYYY-MM"
+
+export type BudgetId = string;
+
+export type Budget = {
+  id: BudgetId;
+  sessionId: string;
+  month: MonthString;             // "YYYY-MM"
+  openingBalance: string;         // API convention: string "1234.56"
+  notes?: string | null;
+  locked?: boolean;               // lock/unlock
+  createdAt?: string;
+  updatedAt?: string;
+};
+
+export type CreateBudgetDto = {
+  sessionId: string;
+  month: MonthString;
+  openingBalance: string;         // "1234.56"
+  notes?: string | null;
+};
+
+export type UpdateBudgetDto = Partial<Pick<Budget, "openingBalance" | "notes" | "locked">>;
+
+export type BudgetSummary = {
+  sessionId: string;
+  month: MonthString;
+  budget?: BudgetId | null      // présent si un budget existe déjà
+  openingBalance: string;         // "1234.56"
+  plannedIncome: string;          // agrégé depuis incomes/expenses
+  plannedExpense: string;         // agrégé depuis incomes/expenses
+  netPlanned: string;              // plannedIncome - plannedExpense
+  projectedEndBalance: string;    // openingBalance + netPlanned
+  actualInFlow: string;                 // agrégé depuis transactions
+  actualOutFlow: string;                // agrégé depuis transactions
+  netActual: string;                     // actualInFlow - actualOutFlow
+  endingBalance: string;                 // projectedEndBalance + netActual
+  clearedInFlow: string;                   // agrégé depuis transactions
+  clearedOutFlow: string;                  // agrégé depuis transactions
+  netCleared: string;                     // clearedInFlow - clearedOutFlow
+  clearedEndingBalance: string;          // endingBalance + netCleared
+};

--- a/src/types/budgets.ts
+++ b/src/types/budgets.ts
@@ -1,4 +1,4 @@
-export type MonthString = `${number}-${string}`; // "YYYY-MM"
+export type MonthString = string // "YYYY-MM"
 
 export type BudgetId = string;
 

--- a/src/types/expenses.ts
+++ b/src/types/expenses.ts
@@ -1,0 +1,35 @@
+import type { Member, BankAccount } from "@/types";
+
+export type ExpenseId = string;
+
+export type Expense = {
+  id: ExpenseId;
+  sessionId: string;
+  memberId: string;
+  bankAccountId: string;
+  label: string;
+  amount: string | number;
+  day: number;
+  category: "HOUSING" | "UTILITIES" | "HEALTH" | "FOOD" | "TRANSPORT" | "SUBSCRIPTIONS" | "OTHER";
+  isArchived?: boolean;
+  createdAt?: string;
+  updatedAt?: string;
+  member?: Member;
+  bankAccount?: BankAccount;
+};
+
+export type CreateExpenseDto = {
+  sessionId: string;
+  memberId: string;
+  bankAccountId: string;
+  label: string;
+  amount: string;
+  day: number;
+  isArchived?: boolean;
+};
+
+export type UpdateExpenseDto = Partial<
+  Pick<Expense, "label" | "day" | "memberId" | "bankAccountId" | "isArchived">
+> & {
+  amount?: string;
+};

--- a/src/types/expenses.ts
+++ b/src/types/expenses.ts
@@ -25,11 +25,12 @@ export type CreateExpenseDto = {
   label: string;
   amount: string;
   day: number;
+  category: Expense["category"];
   isArchived?: boolean;
 };
 
 export type UpdateExpenseDto = Partial<
-  Pick<Expense, "label" | "day" | "memberId" | "bankAccountId" | "isArchived">
+  Pick<Expense, "label" | "day" | "memberId" | "bankAccountId" | "isArchived" | "category">
 > & {
   amount?: string;
 };

--- a/src/types/incomes.ts
+++ b/src/types/incomes.ts
@@ -1,0 +1,30 @@
+export type IncomeId = string;
+
+export type Income = {
+  id: IncomeId;
+  sessionId: string;
+  memberId: string;
+  bankAccountId: string;
+  label: string;
+  amount: string; /** Stocké en base en Decimal → on transporte en string pour éviter les erreurs d'arrondi */
+  day: number; /** Jour du mois (1–31) où le revenu est attendu */
+  createdAt?: string;
+  updatedAt?: string;
+};
+
+export type CreateIncomeDto = {
+  sessionId: string;
+  memberId: string;
+  bankAccountId: string;
+  label: string;
+  amount: string; // ex. "2450.00"
+  day: number;    // 1..31
+};
+
+export type UpdateIncomeDto = Partial<{
+  memberId: string;
+  bankAccountId: string;
+  label: string;
+  amount: string;
+  day: number;
+}>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,3 +3,4 @@ export * from "./sessions";
 export * from "./banks";
 export * from "./incomes";
 export * from "./expenses";
+export * from "./budgets";

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,4 @@
 export * from "./members";
 export * from "./sessions";
 export * from "./banks";
+export * from "./incomes";

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,3 +4,4 @@ export * from "./banks";
 export * from "./incomes";
 export * from "./expenses";
 export * from "./budgets";
+export * from "./transactions";

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,3 +2,4 @@ export * from "./members";
 export * from "./sessions";
 export * from "./banks";
 export * from "./incomes";
+export * from "./expenses";

--- a/src/types/transactions.ts
+++ b/src/types/transactions.ts
@@ -1,0 +1,50 @@
+import type { MonthString } from "@/types";
+
+export type TransactionId = string;
+export type TransactionType = "INFLOW" | "OUTFLOW";
+export type TransactionCategory =
+  | "HOUSING" | "UTILITIES" | "HEALTH" | "FOOD"
+  | "TRANSPORT" | "SUBSCRIPTIONS" | "OTHER";
+
+export type Transaction = {
+  id: TransactionId;
+  sessionId: string;
+  bankAccountId: string;
+  memberId?: string | null;
+  type: TransactionType;
+  label: string;
+  amount: string | number;       // UI peut manipuler number; API attend string
+  date: string;                  // "YYYY-MM-DD"
+  isCleared?: boolean;
+  notes?: string | null;
+  category?: TransactionCategory; // surtout pour OUTFLOW
+  createdAt?: string;
+  updatedAt?: string;
+};
+
+export type CreateTransactionDto = {
+  sessionId: string;
+  bankAccountId: string;
+  memberId?: string | null;
+  type: TransactionType;
+  label: string;
+  amount: string;                // API: "123.45"
+  date: string;                  // "YYYY-MM-DD"
+  category?: TransactionCategory;
+  isCleared?: boolean;
+  notes?: string | null;
+};
+
+export type UpdateTransactionDto = Partial<
+  Pick<
+    Transaction,
+    | "label" | "date" | "memberId" | "bankAccountId"
+    | "notes" | "isCleared" | "category" | "type"
+  >
+> & {
+  amount?: string;               // API string si présent
+};
+
+// Petit helper utile dans le hook
+export type DateRange = { from: string; to: string }; // "YYYY-MM-DD"
+export type MonthRange = { month: MonthString };       // "YYYY-MM"


### PR DESCRIPTION
# Release: J6–J9 — Incomes, Expenses, Budgets, Transactions (MVP)

**Base:** `main`  
**Compare:** `develop`  
**Portée:** Frontend (React + TS + Vite + Zustand + Tailwind + shadcn/ui)  
**But:** Finaliser le MVP utilisateur : revenus/dépenses planifiés, budgets mensuels (édition & lock), transactions (CRUD + cleared), UX responsive + i18n.

---

## 📌 Résumé
- **J6** Revenus planifiés — CRUD par session.
- **J7** Dépenses planifiées — CRUD + archive.
- **J8** Budgets — résumé mensuel, **création auto** si inexistant, **édition solde d’ouverture/notes**, **lock/unlock**, UI lisible (hero Planned/Actual/Cleared).
- **J9** Transactions — liste + filtres (mois/compte/membre/cleared/recherche), **CRUD**, **toggle cleared**, **CSV**, **URL state**, **debounce**, **skeletons**.

✔️ Conformes aux endpoints WalletWiz API.  
✔️ i18n FR/EN.  
✔️ Mobile-first.

---

## 🔌 Endpoints touchés (rappel)
- **Incomes**:  
  `GET/POST/PATCH/DELETE /incomes` (+ `/incomes/session/{sessionId}`)
- **Expenses**:  
  `GET/POST/PATCH/DELETE /expenses` (+ `/expenses/session/{sessionId}`)
- **Budgets**:  
  `GET /budgets/session/{sessionId}/{month}/summary?createIfMissing=true`  
  `GET /budgets/session/{sessionId}?month=YYYY-MM`  
  `POST /budgets` · `PATCH /budgets/{id}` · `DELETE /budgets/{id}`
- **Transactions**:  
  `GET /transactions/session/{sessionId}?from=YYYY-MM-DD&to=YYYY-MM-DD`  
  `POST /transactions` · `PATCH /transactions/{id}` · `DELETE /transactions/{id}`

---

## 🧾 Changelog (user-facing)
### Nouvelles fonctionnalités
- Gestion **Revenus planifiés** (création, édition, suppression).
- Gestion **Dépenses planifiées** + **Archivage**.
- **Budgets**:  
  - Résumé mensuel clair (Hero + onglets **Planned / Actual / Cleared**).  
  - **Édition** du solde d’ouverture & notes.  
  - **Lock/Unlock** du budget.
  - **Création automatique** du budget si absent (utilisation transparente).
- **Transactions**:  
  - **CRUD** complet + **toggle “Cleared”**.  
  - **Filtres**: mois, compte, membre, pointage, recherche.  
  - **Export CSV**, **recherche debounce**, **filtres persistés dans l’URL**, **skeletons**, **raccourcis** (`/` focus recherche, `n` nouvelle transaction).

### Améliorations UX/UI
- Grilles **responsive** (mobile → desktop).
- Table transactions **header sticky**.
- Montants avec **signal visuel** (+ vert / − rouge).
- Badges **catégories** (FOOD, HOUSING, …).
- A11y de base (aria-label, aria-live).

---

## 🧩 Détails techniques
- **Types & Services**: incomes, expenses, budgets (summary.budget = `Budget`), transactions.  
- **Hooks**:
  - `useBudgetSummary`: anti-double-fetch, ensure & sync `summary.budget`, `updateOpening/Notes`, `lock/unlock`.  
  - `useTransactions`: période (mois), filtres client, `create/update/toggle/remove`, totaux.  
  - `useTxUrlState`, `useDebouncedValue`.  
- **Pages**:
  - `/dashboard/incomes`, `/dashboard/expenses`, `/dashboard/budgets`, `/dashboard/transactions`.  
- **i18n**: clés ajoutées FR/EN.  

---

## ✅ QA / Scénarios de test
1. **Auth & Session**  
   - Se connecter, sélectionner une **session active**.
2. **Incomes/Expenses**  
   - Créer/éditer/supprimer un revenu & une dépense.  
   - Archiver/désarchiver une dépense.  
   - Les totaux changent dans le **Budget (Planned)**.
3. **Budgets**  
   - Mois sans budget → **éditer** le solde d’ouverture ⇒ **création auto** + mise à jour du Hero.  
   - Éditer **notes** ⇒ visible après refresh.  
   - **Lock** puis tenter l’édition ⇒ boutons désactivés.  
   - Onglets Planned / Actual / Cleared changent les chiffres affichés.
4. **Transactions**  
   - Créer IN/OUT (montant → string), voir dans la liste du mois courant.  
   - **Toggle Cleared** ⇒ l’état visuel change, CSV/filtre réagit.  
   - Filtres compte/membre/cleared/recherche ⇒ URL se met à jour, Back/Forward cohérents.  
   - Export **CSV** ⇒ fichier téléchargé.  
5. **Responsive & A11y**  
   - Mobile: cartes claires; Desktop: table scrollable header sticky.  
   - Pas d’erreurs console.

---

## ⚠️ Risques & Mitigations
- **Budget inexistant** (404) ⇒ géré par `ensureBudgetIdOrCreate` (création + sync locale).  
- **Montants** number/string ⇒ normalisation `"xx.yy"` dans services & hooks.  
- **Appels redondants** ⇒ gardes `inFlight` dans hooks.  
- **URLs invalides** (`[object Object]`) ⇒ **normalisation id** dans `budgets.service.update/remove`.  
- **Changement de types** (`summary.budget` → `Budget`) ⇒ hook mis à jour, pages OK.

---

## 🔙 Rollback
- Revenir au tag précédent (`v0.5.x`) ou revert du merge commit.  
- Pas de migration DB côté front.  
- Aucun changement irréversible côté client.

---

## 📦 Post-merge / Release
- Tag: `v0.6.0` — *WalletWiz MVP J6–J9*  
- Générer release notes (copier le présent changelog).  
- Build & publish image Docker front.  
- Déploiement via Portainer (VPS Debian 12, Nginx proxy).

---

## ✅ Checklist pré-merge
- [ ] Lint OK (`npm run lint`)  
- [ ] Build OK (`npm run build`)  
- [ ] i18n FR/EN complets  
- [ ] Responsive de base validé  
- [ ] No console error  
- [ ] Docs J6–J9 en place

---

## 🔗 PRs liées (si découpage par jalon)
- feat/j6-incomes → develop
- feat/j7-expenses → develop
- fix/j8-budgets → develop
- feat/j9-transactions → develop
